### PR TITLE
added autotools-brokensep workaround for split-build failure

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -16,4 +16,4 @@ S = "${WORKDIR}/otp_src_${UPSTREAM_VERSION}"
 
 PARALLEL_MAKE = ""
 
-inherit autotools
+inherit autotools-brokensep


### PR DESCRIPTION
Add workaround until better fix.
