### PR TITLE
mix.bbclass: Fix mix release erts path

### DIFF
--- a/classes/mix.bbclass
+++ b/classes/mix.bbclass
@@ -16,7 +16,7 @@ MIX_RELEASE_DIR="${B}/_build/${MIX_ENV}"
 
 export MIX_REBAR3="${WORKDIR}/recipe-sysroot-native/usr/bin/rebar3"
 
-export MIX_TARGET_INCLUDE_ERTS = "${STAGING_LIBDIR}/erlang"
+export ERLANG_ERTS_VERSION = "$(erl -version 2>&1 | gawk '{print $NF}' | tr -d '\n\r')"
 
 def get_release_name(pn):
     pn = pn.split("-")
@@ -35,6 +35,7 @@ mix_do_compile() {
 }
 
 mix_do_install() {
+    MIX_TARGET_INCLUDE_ERTS="${STAGING_LIBDIR}/erlang/erts-${ERLANG_ERTS_VERSION}" \
     MIX_ENV=${MIX_ENV} mix release --overwrite
 
     install -d ${erlang_release}


### PR DESCRIPTION
Without this change building a mix release does not work on meta-erlang master, since the erts path is wrong. The directory erts-<version> is now appended to it.

Tested with erlang 23.2.1 and elixir 1.11.2