### PR TITLE
erlang: remove rpath

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -15,6 +15,7 @@ DEPENDS_append_class-nativesdk = " erlang-native nativesdk-zlib nativesdk-openss
 SRC_URI = "git://github.com/erlang/otp;branch=master"
 SRC_URI += "file://fix-wx-configure.patch"
 SRC_URI += "file://erlang-fix-build-issue-in-Yocto.patch"
+SRC_URI += "file://otp-0002-Remove-rpath.patch"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/erlang/files/otp-0002-Remove-rpath.patch
+++ b/recipes-devtools/erlang/files/otp-0002-Remove-rpath.patch
@@ -1,0 +1,32 @@
+From: Peter Lemenkov <lemenkov@gmail.com>
+Date: Thu, 25 Feb 2010 16:57:43 +0300
+Subject: [PATCH] Remove rpath
+
+Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>
+
+diff --git a/lib/crypto/c_src/Makefile.in b/lib/crypto/c_src/Makefile.in
+index ecccc33d8d..149ed127ff 100644
+--- a/lib/crypto/c_src/Makefile.in
++++ b/lib/crypto/c_src/Makefile.in
+@@ -120,7 +120,7 @@ TEST_ENGINE_LIB = $(LIBDIR)/otp_test_engine$(TYPEMARKER).@DED_EXT@
+ DYNAMIC_CRYPTO_LIB=@SSL_DYNAMIC_ONLY@
+ 
+ ifeq ($(DYNAMIC_CRYPTO_LIB),yes)
+-SSL_DED_LD_RUNTIME_LIBRARY_PATH = @SSL_DED_LD_RUNTIME_LIBRARY_PATH@
++SSL_DED_LD_RUNTIME_LIBRARY_PATH =
+ CRYPTO_LINK_LIB=$(SSL_DED_LD_RUNTIME_LIBRARY_PATH) -L$(SSL_LIBDIR) -l$(SSL_CRYPTO_LIBNAME)
+ EXTRA_FLAGS = -DHAVE_DYNAMIC_CRYPTO_LIB
+ else
+diff --git a/lib/crypto/priv/Makefile b/lib/crypto/priv/Makefile
+index ff9d3e1dc9..d3aba77808 100644
+--- a/lib/crypto/priv/Makefile
++++ b/lib/crypto/priv/Makefile
+@@ -61,7 +61,7 @@ OBJS = $(OBJDIR)/crypto.o
+ # ----------------------------------------------------
+ 
+ $(SO_NIFLIB): $(OBJS)
+-	$(SO_LD) $(SO_LDFLAGS) -L$(SO_SSL_LIBDIR) -Wl,-R$(SO_SSL_LIBDIR) \
++	$(SO_LD) $(SO_LDFLAGS) -L$(SO_SSL_LIBDIR) \
+ 	-o $@ $^ -lcrypto
+ 
+ $(DLL_NIFLIB): $(OBJS)


### PR DESCRIPTION
When building erlang-native, rpath might lead to host contamination.

Borrowed from [1].

1:
https://src.fedoraproject.org/rpms/erlang/blob/rawhide/f/otp-0002-Remove-rpath.patch