### PR TITLE
couchdb: fix b64url build

### DIFF
--- a/recipes-database/couchdb/couchdb.inc
+++ b/recipes-database/couchdb/couchdb.inc
@@ -17,6 +17,10 @@ SPIDERMONKEY_VERSION ?= "60"
 CONFIGUREOPTS = "--with-curl --spidermonkey-version ${SPIDERMONKEY_VERSION} --disable-docs"
 EXTRA_OECONF_remove = "--disable-static"
 
+ERL_INTERFACE_VERSION = "`pkg-config --modversion erl_ei`"
+export ERL_CFLAGS = "`pkg-config --cflags-only-I erl_ei` -I${STAGING_LIBDIR}/erlang/usr/include"
+export ERL_EI_LIBDIR = "${STAGING_LIBDIR}/erlang/lib/erl_interface-${ERL_INTERFACE_VERSION}/lib/"
+
 INITSCRIPT_NAME = "couchdb"
 INITSCRIPT_PARAMS = "defaults"
 


### PR DESCRIPTION
couchdb uses rebar2 that means rebar_port_compiler [1] will handle the C
side. That brings some additional challenges for cross-compile.

So, we need to use the rebar_port_compile environment variables in order
to point to the correct cross-compile sysroot. This commit uses the
pkg-config to get the version of erl_interface and add it into the
ERL_EI_LIBDIR variable. Also the correct include patch comes from pkg-config.

1:
https://github.com/rebar/rebar/blob/b6d309417c502ca243f810e5313bea36951ef038/src/rebar_port_compiler.erl#L145

Fixes: 85