### PR TITLE
erlang: allowing using dialyzer for native and nativesdk

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -130,7 +130,7 @@ do_install_append_class-nativesdk() {
     chown -R root:root ${D}${libdir}/erlang
 }
 
-do_install_append() {
+do_install_append_class-target() {
 	# remove erlang code that does not need to be loaded by the erlang runtime
 	rm -rf ${D}/${libdir}/erlang/lib/erts-${ERTS_VERSION}/ebin
 }


### PR DESCRIPTION
erts is an application that dialyzer uses if configured for (1).

1:
https://github.com/erlang/otp/blob/master/lib/dialyzer/src/dialyzer_cl_parse.erl#L346