### PR TITLE
examples: Add asset compilation to phoenix example

### DIFF
--- a/recipes-examples/hello-phoenix/hello-phoenix_0.1.0.bb
+++ b/recipes-examples/hello-phoenix/hello-phoenix_0.1.0.bb
@@ -10,3 +10,15 @@ PV = "0.1.0-git${SRCPV}"
 SRC_URI = "git://github.com/meta-erlang/hello-world;branch=master;subpath=${BPN}"
 
 inherit mix
+
+DEPENDS_append = " nodejs-native "
+
+MIX_ENV ?= "prod"
+
+# see https://hexdocs.pm/phoenix/releases.html
+do_compile() {
+    MIX_ENV=${MIX_ENV} mix compile
+    npm install --prefix ./assets
+    npm run deploy --prefix ./assets
+    mix phx.digest
+}


### PR DESCRIPTION
Draft because this exact change is not tested yet, but something similar is used in an umbrella app that has one phoenix based application in it.

See https://hexdocs.pm/phoenix/releases.html#releases-assemble

