### PR TITLE
erlang: export EGREP to make AC_EGREP_CPP works

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -46,10 +46,10 @@ EXTRA_OECONF_append_sh4 = " --disable-smp-support --disable-hipe"
 NATIVE_BIN = "${STAGING_LIBDIR_NATIVE}/erlang/bin"
 
 EXTRA_OECONF_class-native ??= " \
-    --with-ssl=${STAGING_DIR_NATIVE}/usr --with-ssl-incl=${STAGING_DIR_NATIVE}/usr \
+    --with-ssl=${STAGING_DIR_NATIVE}/usr --with-ssl-zlib=${STAGING_DIR_NATIVE}/usr \
     "
 EXTRA_OECONF_class-nativesdk ??= " \
-    --with-ssl=${STAGING_DIR_NATIVE}/usr --with-ssl-incl=${STAGING_DIR_NATIVE}/usr \
+    --with-ssl=${STAGING_DIR_NATIVE}/usr --with-ssl-zlib=${STAGING_DIR_NATIVE}/usr \
     "
 
 CACHED_CONFIGUREVARS += "ac_cv_prog_javac_ver_1_2=no ac_cv_prog_javac_ver_1_5=no erl_xcomp_sysroot=${STAGING_DIR_TARGET}"
@@ -57,6 +57,9 @@ CACHED_CONFIGUREVARS_class-native += "ac_cv_prog_javac_ver_1_2=no ac_cv_prog_jav
 CACHED_CONFIGUREVARS_class-nativesdk += "ac_cv_prog_javac_ver_1_2=no ac_cv_prog_javac_ver_1_5=no erl_xcomp_sysroot=${STAGING_DIR_NATIVE}"
 
 OTP_BUILD_CONFIGURE_OPTS ?= "autoconf"
+
+# https://github.com/erlang/otp/issues/4821 setting EGREP to make AC_EGREP_CPP works
+export EGREP = "egrep"
 
 do_configure_class-target() {
     cd ${S}; ./otp_build ${OTP_BUILD_CONFIGURE_OPTS}; cd -

--- a/recipes-devtools/erlang/erlang_24.0.2.bb
+++ b/recipes-devtools/erlang/erlang_24.0.2.bb
@@ -13,6 +13,3 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files/24:"
 OTP_BUILD_CONFIGURE_OPTS = "update_configure --no-commit"
 
 PACKAGECONFIG = "pkgconfig"
-
-EXTRA_OECONF_class-native = ""
-EXTRA_OECONF_class-nativesdk = ""


### PR DESCRIPTION
YP/OE hardknott uses autoconf 2.71 while Erlang/OTP still uses autoconf
2.69 leading to some potential problems. One of then is about the macro
AC_EGREP_CPP which expects the EGREP variable be filled.

The issue [1] has more details about the problem. For while the
erlang.inc exports the EGREP variable to fix the problem when compiling
erlang-native that was not able to find the correct Openssl libraries in
the sysroot-native folder.

Moreover, this commit also introduce the use of '--with-ssl-zlib' to fix
a potential host contamination when building for native and native-sdk.

1: https://github.com/erlang/otp/issues/4821