### PR TITLE
erlfmt: Fix fetch issue because of branch renaming

### DIFF
--- a/recipes-devtools/erlfmt/erlfmt_0.10.0.bb
+++ b/recipes-devtools/erlfmt/erlfmt_0.10.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "erlfmt is an opinionated Erlang code formatter. By automating the
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dcbf253b3d6d09ae7e64cb34b4d0ec33"
 
-SRC_URI = "git://github.com/WhatsApp/erlfmt.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/WhatsApp/erlfmt.git;branch=main;protocol=https"
 
 S = "${WORKDIR}/git"
 SRCREV = "ca8a2378cdc91f9dad47fcfd18b1533132b5711e"

--- a/recipes-devtools/erlfmt/erlfmt_1.0.0.bb
+++ b/recipes-devtools/erlfmt/erlfmt_1.0.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "erlfmt is an opinionated Erlang code formatter. By automating the
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dcbf253b3d6d09ae7e64cb34b4d0ec33"
 
-SRC_URI = "git://github.com/WhatsApp/erlfmt.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/WhatsApp/erlfmt.git;branch=main;protocol=https"
 
 S = "${WORKDIR}/git"
 SRCREV = "b856b95e4a16b48f7b269792af5b844e30c31d9b"


### PR DESCRIPTION
The master branch was renamed to main in the erlfmt repository.
Because of this building meta-erlang-toolchain failed.

This commit fixes this issue.