### PR TITLE
couchdb: 3.1.1 -> 3.1.2

### DIFF
--- a/recipes-database/couchdb/couchdb_3.1.1.bb
+++ b/recipes-database/couchdb/couchdb_3.1.1.bb
@@ -1,4 +1,0 @@
-require ${PN}.inc
-
-SRC_URI[md5sum] = "88d179d439093d8ce3adcbc70592743c"
-SRC_URI[sha256sum] = "8ffe766bba2ba39a7b49689a0732afacf69caffdf8e2d95447e82fb173c78ca3"

--- a/recipes-database/couchdb/couchdb_3.1.2.bb
+++ b/recipes-database/couchdb/couchdb_3.1.2.bb
@@ -1,0 +1,4 @@
+require ${PN}.inc
+
+SRC_URI[md5sum] = "5f975ebe46e0b8ac8cdddb8e0f8cd49a"
+SRC_URI[sha256sum] = "e799c489a9c8fa50c3c40b5267f526d80c93cb57fecafb77ee37f79606f4fb27"


### PR DESCRIPTION
https://docs.couchdb.org/en/stable/whatsnew/3.1.html#version-3-1-2
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38295