### PR TITLE
rabbitmq: fix REDEPENDS variable

### DIFF
--- a/recipes-connectivity/rabbitmq/rabbitmq-server_3.9.8.bb
+++ b/recipes-connectivity/rabbitmq/rabbitmq-server_3.9.8.bb
@@ -29,7 +29,7 @@ DEPENDS = " \
     coreutils-native\
 "
 
-RDEPENDS_${PN} = "erlang erlang-modules"
+RDEPENDS:${PN} = "erlang erlang-modules"
 
 do_unpack:append() {
     bb.build.exec_func('do_fetch_deps', d)


### PR DESCRIPTION
With the Yocto honister release the format of variables has changed. Follow up on that.