### PR TITLE
vernemq: introduce vernemq 1.12.5

### DIFF
--- a/recipes-connectivity/vernemq/files/Makefile.c_src.bcrypt
+++ b/recipes-connectivity/vernemq/files/Makefile.c_src.bcrypt
@@ -1,0 +1,89 @@
+# Based on c_src.mk from erlang.mk by Loic Hoguin <essen@ninenines.eu>
+
+CURDIR := .
+BASEDIR := ..
+
+PROJECT ?= $(notdir $(BASEDIR))
+PROJECT := $(strip $(PROJECT))
+
+ERTS_INCLUDE_DIR ?= $(REBAR3_TARGET_SYSTEM_LIBS)/usr/include
+ERL_INTERFACE_INCLUDE_DIR ?= $(REBAR3_TARGET_SYSTEM_LIBS)/usr/lib
+ERL_INTERFACE_LIB_DIR ?= $(REBAR3_TARGET_SYSTEM_LIBS)/usr/lib
+
+C_SRC_DIR = $(CURDIR)
+C_SRC_NIF = $(CURDIR)/../priv/bcrypt_nif.so
+C_SRC_PORT = $(CURDIR)/../priv/bcrypt
+
+# DRV_LDFLAGS = -shared $(ERL_LDFLAGS) -lpthread
+DRV_CFLAGS = -Ic_src -Wall -O3 -fPIC $(ERL_CFLAGS)
+
+# System type and C compiler/flags.
+
+UNAME_SYS := $(shell uname -s)
+ifeq ($(UNAME_SYS), Darwin)
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -Wall -Wmissing-prototypes
+	LDFLAGS += -flat_namespace -undefined suppress
+	DRV_LDFLAGS = -flat_namespace -undefined suppress $(ERL_LDFLAGS)
+else ifeq ($(UNAME_SYS), Linux)
+	CC ?= gcc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -D_DEFAULT_SOURCE
+	DRV_LDFLAGS = $(ERL_LDFLAGS)
+else # FreeBSD
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	DRV_LDFLAGS = $(ERL_LDFLAGS)
+endif
+
+#   {"DRV_LDFLAGS","-shared $ERL_LDFLAGS -lpthread"},
+#   {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
+#   {"solaris", "ERL_LDFLAGS", "-lxnet -lssp -lnsl $ERL_LDFLAGS"},
+#   {"DRV_CFLAGS","-Ic_src -Wall -O3 -fPIC $ERL_CFLAGS"},
+#   {"CFLAGS", "$CFLAGS -Ic_src -Wall -O3"},
+#   {"LDFLAGS", "$LDFLAGS -lpthread"}
+
+CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei -lpthread
+
+# Verbosity.
+
+c_verbose_0 = @echo " C     " $(?F);
+c_verbose = $(c_verbose_$(V))
+
+cpp_verbose_0 = @echo " CPP   " $(?F);
+cpp_verbose = $(cpp_verbose_$(V))
+
+link_verbose_0 = @echo " LD    " $(@F);
+link_verbose = $(link_verbose_$(V))
+
+SOURCES := $(shell find $(C_SRC_DIR) -type f \( -name "*.c" -o -name "*.C" -o -name "*.cc" -o -name "*.cpp" \))
+OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
+
+COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
+COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
+
+all: $(C_SRC_NIF) $(C_SRC_PORT)
+
+$(C_SRC_PORT): $(OBJECTS)
+	@mkdir -p $(BASEDIR)/priv/
+	$(CC) $(CFLAGS) bcrypt_port.o bcrypt.o blowfish.o $(LDFLAGS) $(DRV_LDFLAGS) $(LDLIBS) -o ../priv/bcrypt
+
+$(C_SRC_NIF): $(OBJECTS)
+	@mkdir -p $(BASEDIR)/priv/
+	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) -shared $(LDLIBS) -o $(C_SRC_NIF)
+
+%.o: %.c
+	$(COMPILE_C) $(OUTPUT_OPTION) $<
+
+%.o: %.cc
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.C
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.cpp
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+clean:
+	@rm -f $(C_SRC_OUTPUT) $(OBJECTS)

--- a/recipes-connectivity/vernemq/files/Makefile.c_src.eleveldb
+++ b/recipes-connectivity/vernemq/files/Makefile.c_src.eleveldb
@@ -1,0 +1,88 @@
+# Based on c_src.mk from erlang.mk by Loic Hoguin <essen@ninenines.eu>
+
+CURDIR := $(shell pwd)
+BASEDIR := $(abspath $(CURDIR)/..)
+
+PROJECT ?= $(notdir $(BASEDIR))
+PROJECT := $(strip $(PROJECT))
+
+ERLANG_VERSION_GT_22 := $(shell erl -noshell -s init stop -eval "erlang:display(erlang:system_info(otp_release) > "22").")
+ERTS_INCLUDE_DIR ?= $(REBAR3_TARGET_SYSTEM_LIBS)/usr/include
+ERL_INTERFACE_INCLUDE_DIR ?= $(REBAR3_TARGET_SYSTEM_LIBS)/usr/lib
+ERL_INTERFACE_LIB_DIR ?= $(REBAR3_TARGET_SYSTEM_LIBS)/usr/lib
+
+C_SRC_DIR = $(CURDIR)
+C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
+
+# System type and C compiler/flags.
+
+UNAME_SYS := $(shell uname -s)
+SNAPPY_STATIC_OR_DYN_LIB := system/lib/libsnappy.a
+
+ifeq ($(UNAME_SYS), Darwin)
+    CC ?= cc
+    CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+    CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall -stdlib=libstdc++
+    LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress  -stdlib=libstdc++
+else ifeq ($(UNAME_SYS), FreeBSD)
+    CC ?= cc
+    CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+    CXXFLAGS ?= -O3 -finline-functions -Wall
+    FREEBSD_MAJOR_VERSION := $(shell uname -U | cut -c1-2)
+
+    ifeq ($(FREEBSD_MAJOR_VERSION), 12)
+        SNAPPY_STATIC_OR_DYN_LIB = /usr/local/lib/libsnappy.so
+    endif
+
+else ifeq ($(UNAME_SYS), Linux)
+    CC ?= gcc
+    CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+    CXXFLAGS ?= -O3 -finline-functions -Wall
+endif
+
+CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I leveldb/include -I leveldb
+CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I leveldb/include -I leveldb
+
+ifeq ($(ERLANG_VERSION_GT_22), true)
+    LDLIBS += -L$(ERL_INTERFACE_LIB_DIR) -lei
+else
+    LDLIBS += -L$(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+endif
+
+LDFLAGS += -shared leveldb/libleveldb.a -lsnappy -lstdc++
+
+# Verbosity.
+
+c_verbose_0 = @echo " C     " $(?F);
+c_verbose = $(c_verbose_$(V))
+
+cpp_verbose_0 = @echo " CPP   " $(?F);
+cpp_verbose = $(cpp_verbose_$(V))
+
+link_verbose_0 = @echo " LD    " $(@F);
+link_verbose = $(link_verbose_$(V))
+
+SOURCES := $(shell find $(C_SRC_DIR) -maxdepth 1 -type f \( -name "*.c" -o -name "*.C" -o -name "*.cc" -o -name "*.cpp" \))
+OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
+
+COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
+COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
+
+$(C_SRC_OUTPUT): $(OBJECTS)
+	@mkdir -p $(BASEDIR)/priv/
+	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) $(LDLIBS) -o $(C_SRC_OUTPUT)
+
+%.o: %.c
+	$(COMPILE_C) $(OUTPUT_OPTION) $<
+
+%.o: %.cc
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.C
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.cpp
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+clean:
+	@rm $(C_SRC_OUTPUT) $(OBJECTS)

--- a/recipes-connectivity/vernemq/files/Makefile.c_src.vmq_passwd
+++ b/recipes-connectivity/vernemq/files/Makefile.c_src.vmq_passwd
@@ -1,0 +1,13 @@
+CC? = gcc
+CFLAGS_EXTRA =
+
+ifeq ($(shell uname -s), Darwin)
+	# OSX with homebrew
+	OPENSSL_DIR ?= /usr/local/opt/openssl
+	CFLAGS_EXTRA += -L${OPENSSL_DIR}/lib -I${OPENSSL_DIR}/include
+endif
+
+all: compile
+
+compile:
+	$(CC) $(CFLAGS) $(CFLAGS_EXTRA) $(LDFLAGS) vmq_passwd.c -lcrypto -o ../priv/vmq_passwd

--- a/recipes-connectivity/vernemq/files/build_deps.sh.eleveldb
+++ b/recipes-connectivity/vernemq/files/build_deps.sh.eleveldb
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/ksh $0 $@
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+
+LEVELDB_VSN="2.0.35"
+
+set -e
+
+if [ `basename $PWD` != "c_src" ]; then
+    # originally "pushd c_src" of bash
+    # but no need to use directory stack push here
+    cd c_src
+fi
+
+BASEDIR="$PWD"
+
+# detecting gmake and if exists use it
+# if not use make
+# (code from github.com/tuncer/re2/c_src/build_deps.sh
+which gmake 1>/dev/null 2>/dev/null && MAKE=gmake
+MAKE=${MAKE:-make}
+
+# Changed "make" to $MAKE
+
+case "$1" in
+    rm-deps)
+        rm -rf leveldb system
+        ;;
+
+    clean)
+        rm -rf system
+        if [ -d leveldb ]; then
+            (cd leveldb && $MAKE clean)
+        fi
+
+        $MAKE clean
+        ;;
+
+    test)
+        export CFLAGS="$CFLAGS -I $BASEDIR/system/include"
+        export CXXFLAGS="$CXXFLAGS -I $BASEDIR/system/include"
+        export LDFLAGS="$LDFLAGS -L$BASEDIR/system/lib"
+        export LD_LIBRARY_PATH="$BASEDIR/system/lib:$LD_LIBRARY_PATH"
+
+        (cd leveldb && $MAKE check)
+
+        ;;
+
+    get-deps)
+        if [ ! -d leveldb ]; then
+            git clone https://github.com/basho/leveldb
+            (cd leveldb && git checkout $LEVELDB_VSN && \
+                    curl -k -fSL https://patch-diff.githubusercontent.com/raw/ioolkos/leveldb/pull/1.diff -o 1.diff && \
+                    patch -p1 -i 1.diff && \
+                    rm -rf 1.diff)
+        fi
+        ;;
+
+    *)
+        export MACOSX_DEPLOYMENT_TARGET=10.8
+
+        export CFLAGS="$CFLAGS -I $BASEDIR/system/include"
+        export CXXFLAGS="$CXXFLAGS -I $BASEDIR/system/include"
+        export LDFLAGS="$LDFLAGS -L$BASEDIR/system/lib"
+        export LD_LIBRARY_PATH="$BASEDIR/system/lib:$LD_LIBRARY_PATH"
+        export LEVELDB_VSN="$LEVELDB_VSN"
+
+        if [ ! -d leveldb ]; then
+            git clone https://github.com/basho/leveldb
+            (cd leveldb && git checkout $LEVELDB_VSN && \
+                    curl -k -fSL https://patch-diff.githubusercontent.com/raw/ioolkos/leveldb/pull/1.diff -o 1.diff && \
+                    patch -p1 -i 1.diff && \
+                    rm -rf 1.diff)
+        fi
+
+        (cd leveldb && $MAKE -j 3 all)
+
+        $MAKE
+        ;;
+esac

--- a/recipes-connectivity/vernemq/files/rebar.config.eleveldb
+++ b/recipes-connectivity/vernemq/files/rebar.config.eleveldb
@@ -1,0 +1,18 @@
+%%-*- mode: erlang -*-
+{eunit_opts, [verbose]}.
+
+{xref_checks,[undefined_function_calls,undefined_functions,locals_not_used,
+    deprecated_function_calls, deprecated_functions]}.
+
+{port_sources, ["c_src/*.cc"]}.
+
+{erl_opts, [warnings_as_errors, debug_info]}.
+
+{artifacts, ["priv/eleveldb.so"]}.
+
+{pre_hooks, [
+	{"(linux|darwin|solaris)", clean, "c_src/build_deps.sh clean"},
+	{"(linux|darwin|solaris)", 'get-deps', "c_src/build_deps.sh get-deps"},
+	{"(linux|darwin|solaris)", compile, "c_src/build_deps.sh"}
+]}.
+

--- a/recipes-connectivity/vernemq/files/vars.config
+++ b/recipes-connectivity/vernemq/files/vars.config
@@ -1,0 +1,55 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ft=erlang ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,      "/usr/bin"}.
+{platform_data_dir,     "/var/lib/vernemq"}.
+{platform_etc_dir,      "/etc/vernemq"}.
+{platform_base_dir,     "/usr/lib/vernemq"}.
+{platform_lib_dir,      "/usr/lib/vernemq/lib"}.
+{platform_log_dir,      "/var/log/vernemq"}.
+{cuttlefish_schema_dir, "/usr/lib/vernemq/share/schema"}.
+{platform_share_dir,    "/usr/share/vernemq"}.
+
+%%
+%% etc/vm.args
+%%
+{node,                  "VerneMQ@127.0.0.1"}.
+{crash_dump,            "/var/log/vernemq/erl_crash.dump"}.
+
+%%
+%% bin/vernemq
+%%
+{runner_script_dir,     "/usr/lib/vernemq/bin"}.
+{runner_base_dir,       "/usr/lib/vernemq"}.
+{runner_etc_dir,        "/etc/vernemq"}.
+{runner_log_dir,        "/var/log/vernemq"}.
+{runner_lib_dir,        "/usr/lib/vernemq/lib"}.
+{runner_patch_dir,      "/usr/lib/vernemq/lib/erlio-patches"}.
+{pipe_dir,              "/tmp/vernemq/"}.
+{runner_user,           "vernemq"}.
+
+{runner_wait_process,   "vmq_cluster_node_sup"}.
+{runner_ulimit_warn,    65536}.
+
+%% vmq_server
+{max_connections, 10000}.
+{max_nr_of_acceptors, 10}.
+{mqtt_default_ip, "127.0.0.1"}.
+{mqtt_default_port, 1883}.
+{mqtt_default_ws_ip, "127.0.0.1"}.
+{mqtt_default_ws_port, 8080}.
+{cluster_default_ip, "0.0.0.0"}.
+{cluster_default_port, 44053}.
+{http_default_ip, "127.0.0.1"}.
+{http_default_port, 8888}.
+{metadata_plugin, vmq_swc}.
+
+%% lager
+{console_log_default, file}.
+
+%%
+%% cuttlefish
+%%
+{cuttlefish,            "on"}.
+{cuttlefish_conf,       "vernemq.conf"}.

--- a/recipes-connectivity/vernemq/files/vernemq-volatiles.conf
+++ b/recipes-connectivity/vernemq/files/vernemq-volatiles.conf
@@ -1,0 +1,1 @@
+d /var/log/vernemq  0755 vernemq vernemq -

--- a/recipes-connectivity/vernemq/files/vernemq.conf
+++ b/recipes-connectivity/vernemq/files/vernemq.conf
@@ -1,0 +1,3 @@
+allow_anonymous = on
+plugins.vmq_acl = off
+listener.http.default = 127.0.0.1:8888

--- a/recipes-connectivity/vernemq/files/vernemq.init
+++ b/recipes-connectivity/vernemq/files/vernemq.init
@@ -1,0 +1,103 @@
+#! /bin/sh
+
+NAME=vernemq
+VERNECTL=/usr/lib/vernemq/bin/vernemq
+SCRIPTNAME=/etc/init.d/$NAME
+
+#
+# Function that starts the vernemq service
+#
+do_start()
+{
+    # Return
+    #   0 if vernemq has been started
+    #   1 if vernemq was already running
+    #   2 if vernemq could not be started
+    $VERNECTL start
+
+    local RC=$?
+    if [ $RC -gt 1 -o $RC -lt 0 ]; then
+        return 2;
+    fi
+
+    return $RC
+}
+
+#
+# Function that stops the vernemq service
+#
+do_stop()
+{
+    # Return
+    #   0 if vernemq has been stopped
+    #   1 if vernemq was already stopped
+    #   other if a failure occurred
+    $VERNECTL stop
+}
+
+#
+# Function that graceful reload the vernemqi service
+#
+do_reload() {
+    # Return
+    #   0 if vernemq has been restarted
+    #   1 if vernemq was not started in the first place
+    #   other if a failure occurred
+    $VERNECTL restart
+}
+
+# Checks the status of vernemq service
+do_status() {
+    $VERNECTL ping > /dev/null && echo $"$NAME is running" && return 0
+    echo $"$NAME is stopped" && return 2
+}
+
+case "$1" in
+    start)
+        echo -n "Starting $NAME "
+        do_start
+        case "$?" in
+            0|1) exit 0 ;;
+            2) exit 1 ;;
+        esac
+        ;;
+    stop)
+        echo -n "Stopping $NAME "
+        do_stop
+        case "$?" in
+            0|1) exit 0 ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    status)
+        do_status
+        ;;
+    reload|force-reload)
+        echo -n "Reloading $NAME "
+        do_reload
+        ES=$?
+        exit $ES
+        ;;
+    restart)
+        echo -n "Restarting $NAME "
+        do_stop
+        case "$?" in
+            0|1)
+                do_start
+                case "$?" in
+                    0)  exit 0 ;;
+                    1)  exit 1 ;; # Old process is still running
+                    *)  exit 1 ;; # Failed to start
+                esac
+                ;;
+            *)
+                # Failed to stop
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "Usage: $SCRIPTNAME {start|stop|status|restart|reload|force-reload}" >&2
+        exit 3
+        ;;
+esac

--- a/recipes-connectivity/vernemq/files/vernemq.service
+++ b/recipes-connectivity/vernemq/files/vernemq.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Runner for VerneMQ
+After=network.target
+
+[Service]
+WorkingDirectory=/var/lib/vernemq
+User=vernemq
+Group=vernemq
+ExecStart=/usr/lib/vernemq/bin/vernemq start
+ExecStop=/usr/lib/vernemq/bin/vernemq stop
+Type=forking
+Restart=always
+RestartSec=45
+LimitNOFILE=300000
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-connectivity/vernemq/files/vm.args
+++ b/recipes-connectivity/vernemq/files/vm.args
@@ -1,0 +1,2 @@
+-name vernemq
+-setcookie vernemq

--- a/recipes-connectivity/vernemq/files/volatiles.99_vernemq
+++ b/recipes-connectivity/vernemq/files/volatiles.99_vernemq
@@ -1,0 +1,3 @@
+# <type> <owner> <group> <mode> <path> <linksource>
+d vernemq vernemq 0755 /var/log/vernemq none
+

--- a/recipes-connectivity/vernemq/vernemq_1.12.5.bb
+++ b/recipes-connectivity/vernemq/vernemq_1.12.5.bb
@@ -1,0 +1,92 @@
+SUMMARY = "A distributed MQTT message broker based on Erlang/OTP. Built for high quality & Industrial use cases."
+
+DESCRIPTION = "VerneMQ is a high-performance, distributed MQTT message broker. It scales horizontally \
+and vertically on commodity hardware to support a high number of concurrent publishers and consumers \
+while maintaining low latency and fault tolerance. VerneMQ is the reliable message hub for your IoT \
+platform or smart products."
+
+HOMEPAGE = "https://vernemq.com"
+
+SECTION = "network"
+
+DEPENDS = "erlang-native rebar3-native curl-native \
+           erlang openssl snappy \
+          "
+
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=11fe9db289207b0e40d83d07f5e0727e"
+
+SRC_URI = "git://github.com/vernemq/vernemq;protocol=https;branch=master \
+           file://vars.config \
+           file://vm.args \
+           file://vernemq.conf \
+           file://vernemq-volatiles.conf \
+           file://vernemq.service \
+           file://vernemq.init \
+           file://volatiles.99_vernemq \
+           file://rebar.config.eleveldb \
+           file://build_deps.sh.eleveldb \
+           file://Makefile.c_src.eleveldb \
+           file://Makefile.c_src.bcrypt \
+           file://Makefile.c_src.vmq_passwd \
+          "
+
+SRCREV = "50adf26e093a4d5a073964be2b322494e411a126"
+PR = "r0"
+
+S = "${WORKDIR}/git"
+
+inherit rebar3-brokensep useradd update-rc.d systemd
+
+REBAR3_RELEASE_NAME = "vernemq"
+REBAR3_PROFILE = "default"
+
+do_compile:prepend() {
+    # fix dependency: eleveldb
+    install -D ${WORKDIR}/build_deps.sh.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/c_src/build_deps.sh
+    install -D ${WORKDIR}/Makefile.c_src.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/c_src/Makefile
+    install -D ${WORKDIR}/rebar.config.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/rebar.config
+
+    # fix dependency: bcrypt
+    install -D ${WORKDIR}/Makefile.c_src.bcrypt ${REBAR_BASE_DIR}/default/lib/bcrypt/c_src/Makefile
+
+    # fix dependency: vmq_passwd
+    install -D ${WORKDIR}/Makefile.c_src.vmq_passwd ${S}/apps/vmq_passwd/c_src/Makefile
+}
+
+do_install:prepend() {
+    cd ${S}
+    cat ${WORKDIR}/vars.config > vars.generated
+    echo "{app_version, \"${PV}\"}." >> vars.generated
+}
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/vernemq
+    install -m 0644 ${WORKDIR}/vm.args ${D}${sysconfdir}/vernemq/vm.args
+    install -m 0644 ${WORKDIR}/vernemq.conf ${D}${sysconfdir}/vernemq/vernemq.conf
+    chown -R vernemq.vernemq ${D}${sysconfdir}/vernemq
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system
+        install -m 0644 ${WORKDIR}/vernemq.service ${D}${systemd_unitdir}/system
+        install -d ${D}${sysconfdir}/tmpfiles.d/
+        install -m 0644 ${WORKDIR}/vernemq-volatiles.conf ${D}${sysconfdir}/tmpfiles.d/vernemq.conf
+    fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
+        install -d ${D}${sysconfdir}/init.d
+        install -m 0755 ${WORKDIR}/vernemq.init ${D}${sysconfdir}/init.d/vernemq
+        install -d ${D}${sysconfdir}/default/volatiles
+        install -m 0644 ${WORKDIR}/volatiles.99_vernemq ${D}${sysconfdir}/default/volatiles/99_vernemq
+    fi
+}
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = "--system --create-home --home-dir ${localstatedir}/lib/vernemq \
+    --shell /bin/false --user-group vernemq"
+
+SYSTEMD_SERVICE:${PN} = "vernemq.service"
+
+INITSCRIPT_NAME = "vernemq"
+INITSCRIPT_PARAMS = "defaults"


### PR DESCRIPTION
Add vernemq. Not fully tested yet. But the recipe builds fine.

I've used a x86-64 machine. As I suspect the eleveldb will not work for x86-32bits.

What is missing:

- [x] try run vernemq on qemux86-64 machine
- [x] check and fix users, init scripts
- [x] overall vernemq testing according to its documentation 


https://github.com/meta-erlang/meta-erlang/issues/158