### PR TITLE
livebook: fix build on kirkstone

### DIFF
--- a/recipes-devtools/livebook/livebook_0.5.2.bb
+++ b/recipes-devtools/livebook/livebook_0.5.2.bb
@@ -14,6 +14,7 @@ SRC_URI = "git://github.com/elixir-nx/livebook;branch=main;protocol=https \
 RDEPENDS:${PN} = "erlang erlang-modules elixir"
 
 inherit mix systemd useradd
+do_configure[network] = "1"
 
 do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then


### PR DESCRIPTION
For livebook, the do_configure step uses Mix, which in turn uses
the network to pull metadata. On Kirkstone and newer yocto releases,
kernel automatically disables the networking support for tasks other
than do_fetch, and such support must be enabled explicitly in the
recipe[1].

Current fix explicitly enables the networking support.

Error message:
```
| DEBUG: Executing shell function do_configure
| ** (Mix) httpc request failed with: {:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
|
| Could not install Rebar because Mix could not download metadata at https://repo.hex.pm/installs/rebar-1.x.csv.
|
| WARNING: exit code 1 from a shell command.
ERROR: Task ([...]/meta-erlang/recipes-devtools/livebook/livebook_0.5.2.bb:do_configure) failed with exit code '1'
```

Reference:
[1] https://docs.yoctoproject.org/dev/migration-guides/migration-4.0.html#fetching-changes