### PR TITLE
Enable network support for do_configure task

### DIFF
--- a/classes/mix.bbclass
+++ b/classes/mix.bbclass
@@ -10,6 +10,8 @@ MIX_ENV ?= "prod"
 # erlang system libs, target system was striped
 INSANE_SKIP:${PN} += "already-stripped"
 
+do_configure[network] = "1"
+
 MIX_RELEASE_NAME="${@get_release_name("${PN}")}"
 MIX_RELEASE_VERSION="${@get_release_version("${PV}")}"
 MIX_RELEASE_DIR="${B}/_build/${MIX_ENV}"

--- a/classes/rebar3.bbclass
+++ b/classes/rebar3.bbclass
@@ -12,6 +12,8 @@ export REBAR_BASE_DIR = "${B}"
 # erlang system libs, target system was striped
 INSANE_SKIP:${PN} += "already-stripped"
 
+do_configure[network] = "1"
+
 REBAR3_PROFILE ?= ""
 REBAR3_RELEASE_NAME ?= "${@make_release_name("${PN}")}"
 REBAR3_RELEASE ?= "${REBAR3_RELEASE_NAME}-${@get_erlang_release("${PV}")}"


### PR DESCRIPTION
Usually the do_fetch is allowed to fetch external resources. But for mix
and rebar3 recipes that happens on do_configure task due how these tools
works.

This enables network support for do_configure task [1].

1: https://docs.yoctoproject.org/dev/migration-guides/migration-4.0.html#fetching-changes