### PR TITLE
yanger: install yanger artifacts

### DIFF
--- a/recipes-devtools/yanger/files/0001-Add-install-rule.patch
+++ b/recipes-devtools/yanger/files/0001-Add-install-rule.patch
@@ -1,0 +1,43 @@
+From 4d4ccd0eaf9c9b02e3940d03dc58ad0569c9eb8c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jo=C3=A3o=20Henrique=20Ferreira=20de=20Freitas?=
+ <joao.freitas@ekinops.com>
+Date: Tue, 14 Jun 2022 14:52:53 -0300
+Subject: [PATCH] Add install rule
+
+A simple rule to install yanger files.
+---
+ Makefile | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 44e6da6..a023cb3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,7 @@
+ SUBDIRS = c_src src plugins
+ 
++PREFIX ?= /usr/lib
++
+ all:
+ 	@set -e ; \
+ 	  for d in $(SUBDIRS) ; do \
+@@ -20,6 +22,16 @@ include vsn.mk
+ dialyzer:
+ 	dialyzer -DVSN=\"$(VSN)\" -pa ../yanger/ebin --src src/*.erl
+ 
++install:
++	install -d $(DESTDIR)$(PREFIX)/yanger/priv
++	install -d $(DESTDIR)$(PREFIX)/yanger/modules
++	install -d $(DESTDIR)$(PREFIX)/yanger/ebin
++	install -d $(DESTDIR)$(PREFIX)/yanger/bin
++	install -m 0664 -t $(DESTDIR)$(PREFIX)/yanger/priv priv/*
++	install -m 0664 -t $(DESTDIR)$(PREFIX)/yanger/modules modules/*
++	install -m 0664 -t $(DESTDIR)$(PREFIX)/yanger/ebin ebin/*
++	install -m 0775 bin/yanger $(DESTDIR)$(PREFIX)/yanger/bin
++
+ # requires 'lux' in the PATH (https://github.com/hawk/lux)
+ # the tree test requires 'pyang' (https://github.com/mbj4668/pyang)
+ # checked out next to 'yanger' and in the PATH
+-- 
+2.25.1
+

--- a/recipes-devtools/yanger/files/environment.d-yanger.sh
+++ b/recipes-devtools/yanger/files/environment.d-yanger.sh
@@ -1,0 +1,2 @@
+# export the YANG_MODPATH
+export YANG_MODPATH=${OECORE_NATIVE_SYSROOT}/usr/lib/yanger/modules:$YANG_MODPATH

--- a/recipes-devtools/yanger/files/yanger.sh
+++ b/recipes-devtools/yanger/files/yanger.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ -z "$YANGER_ROOTDIR" ]
+then
+    ROOTDIR="%ROOTDIR%"
+else
+    ROOTDIR="$YANGER_ROOTDIR"
+fi
+BINDIR=$ROOTDIR/bin
+PROGNAME=`echo $0 | sed 's/.*\///'`
+exec "$BINDIR/yanger" ${1+"$@"}

--- a/recipes-devtools/yanger/yanger_git.bb
+++ b/recipes-devtools/yanger/yanger_git.bb
@@ -3,7 +3,10 @@ DESCRIPTION = "Extensible YANG validator."
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b6e74f10aa07de2cf633fab938ca24ba"
 
-SRC_URI = "git://github.com/mbj4668/yanger.git;branch=master;protocol=https;destsuffix=yanger"
+SRC_URI = "git://github.com/mbj4668/yanger.git;branch=master;protocol=https;destsuffix=yanger \
+    file://environment.d-yanger.sh \
+    file://0001-Add-install-rule.patch \
+    file://yanger.sh"
 
 S = "${WORKDIR}/yanger"
 SRCREV = "7f200aa475cacc05cbdef798c78a1fbeddfd1363"
@@ -19,11 +22,20 @@ do_compile() {
 }
 
 do_install() {
-    install -d 0755 ${D}/${bindir}
-    install -m 0755 ${S}/bin/yanger ${D}/${bindir}/yanger
+    oe_runmake install DESTDIR=${D} PREFIX=${libdir}
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/yanger.sh ${D}${bindir}/yanger
+
+    # install yanger wrapper to find the yanger installation path
+    sed -i -e "s:%ROOTDIR%:${libdir}/yanger:g" ${D}${bindir}/yanger
 }
 
-FILES_${PN} = "${bindir}/yanger"
+do_install_append_class-nativesdk() {
+    # install environment setup to load yang modules
+    mkdir -p ${D}${SDKPATHNATIVE}/environment-setup.d 
+    install -m 644 ${WORKDIR}/environment.d-yanger.sh ${D}${SDKPATHNATIVE}/environment-setup.d/yanger.sh
+}
 
 BBCLASSEXTEND = "native nativesdk"
 
+FILES_${PN}_append_class-nativesdk = " ${SDKPATHNATIVE}/environment-setup.d/yanger.sh"


### PR DESCRIPTION
yanger does not provide a make install rule. So this commit creates that
rule in order to install the project. This is important when using
yanger with nativesdk.