### PR TITLE
erlang_ls: 0.28.0 -> 0.44.1

### DIFF
--- a/recipes-devtools/erlang_ls/erlang-ls_0.44.1.bb
+++ b/recipes-devtools/erlang_ls/erlang-ls_0.44.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=7f313310d7132582da56ae0c7feeb2d2"
 
 SRC_URI = "git://github.com/erlang-ls/erlang_ls;branch=main;protocol=https"
 
-SRCREV = "9eed7d4e865b6ad8a653cb495944bda53bf82db1"
+SRCREV = "b151f9d9a4a1dde1118ae2822226500e2fa69125"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Use 0.44.1 as it looks vscode has a better support for it.