### PR TITLE
erlang_ls: 0.46.2 -> 0.44.1

### DIFF
--- a/recipes-devtools/erlang_ls/erlang-ls_0.44.1.bb
+++ b/recipes-devtools/erlang_ls/erlang-ls_0.44.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=7f313310d7132582da56ae0c7feeb2d2"
 
 SRC_URI = "git://github.com/erlang-ls/erlang_ls;branch=main;protocol=https"
 
-SRCREV = "229175ec35afddbb5c5a0ac2cf25423d7aa0b6ab"
+SRCREV = "b151f9d9a4a1dde1118ae2822226500e2fa69125"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Use 0.44.1 as it looks vscode has a better support for it.