### PR TITLE
livebook: add elixir-mix as RDEPENDS

### DIFF
--- a/recipes-devtools/livebook/livebook_0.5.2.bb
+++ b/recipes-devtools/livebook/livebook_0.5.2.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://github.com/elixir-nx/livebook;branch=main;protocol=https \
            file://livebook.service \
            file://livebook.conf" 
 
-RDEPENDS_${PN} = "erlang erlang-modules elixir"
+RDEPENDS_${PN} = "erlang erlang-modules elixir elixir-mix"
 
 inherit mix systemd useradd
 


### PR DESCRIPTION
livebook has some use cases where the user could install additional elixir dependencies. And mix is necessary to be installed.