### PR TITLE
allow hex configuration to be supplied aka private hexpm organisation

### DIFF
--- a/classes/mix.bbclass
+++ b/classes/mix.bbclass
@@ -36,10 +36,10 @@ mix_do_configure() {
         mix local.rebar --force
     fi
     mix local.hex --force
-    mix deps.get
 }
 
 mix_do_compile() {
+    mix deps.get
     MIX_ENV=${MIX_ENV} mix compile
 }
 


### PR DESCRIPTION
you don't have a chance to put the hexpm token for an organisation with the current implementation.

it allows you to do something like:

mix_do_configure:append() {
   mix hex.organization auth ORG --key "${HEX_TOKEN}"
}
