### PR TITLE
erlang: do not change ROOTDIR for erl and start scripts

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -123,10 +123,6 @@ do_install:class-target() {
     PATH=${NATIVE_BIN}:$PATH \
     oe_runmake 'DESTDIR=${D}' install
     oe_runmake 'DESTDIR=${D}' install-docs DOC_TARGETS=chunks
-    for f in erl start
-        do sed -i -e 's:ROOTDIR=.*:ROOTDIR=${libdir}/erlang:' \
-            ${D}/${libdir}/erlang/erts-${ERTS_VERSION}/bin/$f ${D}/${libdir}/erlang/bin/$f
-    done
 
     cp ${D}/${libdir}/erlang/erts-${ERTS_VERSION}/bin/dyn_erl ${D}/${libdir}/erlang/erts-${ERTS_VERSION}/bin/erl
 


### PR DESCRIPTION
Commit [1] adds the possibility to run Erlang installation system location independently.

1: https://github.com/erlang/otp/commit/5ea1d07c17447ff114879b292d4b9d461c191ccd