### PR TITLE
Allow B to be set externally

### DIFF
--- a/classes/atomvm.bbclass
+++ b/classes/atomvm.bbclass
@@ -5,9 +5,9 @@ RDEPENDS:${PN} += "atomvm"
 
 RCONFLICTS:${PN} += "atomvm-examples"
 
-B = "${WORKDIR}/build"
+B ?= "${WORKDIR}/build"
 
-# support REBAR_BASE_DIR for setting the base_dir 
+# support REBAR_BASE_DIR for setting the base_dir
 # https://github.com/erlang/rebar3/commit/9402857f5527e300bf28b7e3744bef3fc88f3379
 export REBAR_BASE_DIR = "${B}"
 

--- a/classes/mix.bbclass
+++ b/classes/mix.bbclass
@@ -3,7 +3,7 @@ inherit erlang pkgconfig
 
 DEPENDS += "elixir-native"
 
-B = "${S}"
+B ?= "${S}"
 
 MIX_ENV ?= "prod"
 
@@ -59,7 +59,7 @@ mix_do_install() {
     MIX_TARGET_INCLUDE_ERTS="${STAGING_LIBDIR}/erlang/erts-${ERLANG_ERTS_VERSION}" \
     MIX_ENV=${MIX_ENV} mix release --overwrite --path ${erlang_release}
 
-    chown root:root -R ${erlang_release}    
+    chown root:root -R ${erlang_release}
 }
 
 EXPORT_FUNCTIONS do_configure do_compile do_install

--- a/classes/rebar.bbclass
+++ b/classes/rebar.bbclass
@@ -3,4 +3,4 @@ inherit erlang
 
 DEPENDS += "rebar-native"
 
-B = "${S}"
+B ?= "${S}"

--- a/classes/rebar3-brokensep.bbclass
+++ b/classes/rebar3-brokensep.bbclass
@@ -1,3 +1,3 @@
 inherit rebar3
 export REBAR_BASE_DIR = "${S}/_build"
-B = "${S}"
+B ?= "${S}"

--- a/classes/rebar3.bbclass
+++ b/classes/rebar3.bbclass
@@ -3,9 +3,9 @@ inherit erlang pkgconfig
 
 DEPENDS += "rebar3-native gawk-native"
 
-B = "${WORKDIR}/build"
+B ?= "${WORKDIR}/build"
 
-# support REBAR_BASE_DIR for setting the base_dir 
+# support REBAR_BASE_DIR for setting the base_dir
 # https://github.com/erlang/rebar3/commit/9402857f5527e300bf28b7e3744bef3fc88f3379
 export REBAR_BASE_DIR = "${B}"
 

--- a/recipes-extended/mozjs/mozjs-91_91.13.0.bb
+++ b/recipes-extended/mozjs/mozjs-91_91.13.0.bb
@@ -27,7 +27,7 @@ DEPENDS += "zlib cargo-native python3 icu"
 DEPENDS:remove:mipsarch = "icu"
 DEPENDS:remove:powerpc:toolchain-clang = "icu"
 
-B = "${WORKDIR}/build"
+B ?= "${WORKDIR}/build"
 
 export PYTHONPATH = "${S}/build:${S}/third_party/python/PyYAML/lib3:${S}/testing/mozbase/mozfile:${S}/python/mozboot:${S}/third_party/python/distro:${S}/testing/mozbase/mozinfo:${S}/config:${S}/testing/mozbase/manifestparser:${S}/third_party/python/pytoml:${S}/testing/mozbase/mozprocess:${S}/third_party/python/six:${S}/python/mozbuild:${S}/python/mozbuild/mozbuild:${S}/python/mach:${S}/third_party/python/jsmin:${S}/python/mozversioncontrol"
 


### PR DESCRIPTION
This is useful if you are building from a SRC repository where the mix / erlang project is in a subdirectory of the repo.