### PR TITLE
recipes: Transition from WORKDIR to UNPACKDIR

### DIFF
--- a/classes/atomvm.bbclass
+++ b/classes/atomvm.bbclass
@@ -20,7 +20,7 @@ export ERL_COMPILER_OPTIONS="deterministic"
 
 REBAR3_PROFILE ?= "default"
 
-export REBAR_CACHE_DIR = "${WORKDIR}/rebar3-cache"
+export REBAR_CACHE_DIR = "${UNPACKDIR}/rebar3-cache"
 
 atomvm_do_configure() {
     # This is needed since the default is to be in ${B}. In fact all the task

--- a/classes/mix-rebar3.bbclass
+++ b/classes/mix-rebar3.bbclass
@@ -5,4 +5,4 @@ inherit mix
 
 DEPENDS += "rebar3-native"
 
-export MIX_REBAR3 ?= "${WORKDIR}/recipe-sysroot-native/usr/bin/rebar3"
+export MIX_REBAR3 ?= "${UNPACKDIR}/recipe-sysroot-native/usr/bin/rebar3"

--- a/classes/mix.bbclass
+++ b/classes/mix.bbclass
@@ -19,7 +19,7 @@ MIX_RELEASE_NAME="${@get_release_name("${PN}")}"
 MIX_RELEASE_VERSION="${@get_release_version("${PV}")}"
 MIX_RELEASE_DIR="${B}/_build/${MIX_ENV}"
 
-export MIX_HOME = "${WORKDIR}/mix"
+export MIX_HOME = "${UNPACKDIR}/mix"
 export MIX_ARCHIVES = "${MIX_HOME}/archives"
 
 export ERL_COMPILER_OPTIONS="deterministic"

--- a/classes/rebar3.bbclass
+++ b/classes/rebar3.bbclass
@@ -24,7 +24,7 @@ export REBAR3_TARGET_SYSTEM = "${STAGING_LIBDIR}/erlang"
 export REBAR3_TARGET_INCLUDE_ERTS = "${REBAR3_TARGET_SYSTEM}"
 export REBAR3_TARGET_SYSTEM_LIBS = "${REBAR3_TARGET_SYSTEM}/lib"
 
-export REBAR_CACHE_DIR = "${WORKDIR}/rebar3-cache"
+export REBAR_CACHE_DIR = "${UNPACKDIR}/rebar3-cache"
 
 # rebar3 new cmake
 export ERTS_INCLUDE_DIR = "${STAGING_LIBDIR}/erlang/usr/include"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 BBFILE_COLLECTIONS += "erlang-layer"
 BBFILE_PATTERN_erlang-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_erlang-layer = "7"
-LAYERSERIES_COMPAT_erlang-layer = "nanbield scarthgap styhead"
+LAYERSERIES_COMPAT_erlang-layer = "styhead"
 
 LAYERDEPENDS_erlang-layer = "core"
 

--- a/recipes-connectivity/rabbitmq/rabbitmq-server_3.11.28.bb
+++ b/recipes-connectivity/rabbitmq/rabbitmq-server_3.11.28.bb
@@ -88,22 +88,22 @@ do_install() {
     chown -R rabbitmq.rabbitmq ${D}/${sysconfdir}/rabbitmq
 
     install -d ${D}${sysconfdir}/default/volatiles
-    install -m 0644 ${WORKDIR}/volatiles.99_rabbitmq-server ${D}${sysconfdir}/default/volatiles/99_rabbitmq-server
+    install -m 0644 ${UNPACKDIR}/volatiles.99_rabbitmq-server ${D}${sysconfdir}/default/volatiles/99_rabbitmq-server
 
-    install -m 644 ${WORKDIR}/rabbitmq.conf ${D}/${sysconfdir}/rabbitmq/rabbitmq.conf
+    install -m 644 ${UNPACKDIR}/rabbitmq.conf ${D}/${sysconfdir}/rabbitmq/rabbitmq.conf
     chown rabbitmq.rabbitmq ${D}/${sysconfdir}/rabbitmq/rabbitmq.conf
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'true', 'false', d)}; then
         install -d ${D}${sysconfdir}/init.d
-        install -m 0755 ${WORKDIR}/rabbitmq-server ${D}${sysconfdir}/init.d/rabbitmq-server
-        install -m 0755 ${WORKDIR}/rabbitmq-server-setup ${D}${bindir}
+        install -m 0755 ${UNPACKDIR}/rabbitmq-server ${D}${sysconfdir}/init.d/rabbitmq-server
+        install -m 0755 ${UNPACKDIR}/rabbitmq-server-setup ${D}${bindir}
     fi
 
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/rabbitmq-server.service ${D}${systemd_unitdir}/system
+        install -m 0644 ${UNPACKDIR}/rabbitmq-server.service ${D}${systemd_unitdir}/system
         install -d ${D}${sysconfdir}/tmpfiles.d/
-        install -m 0644 ${WORKDIR}/rabbitmq-server-volatiles.conf ${D}${sysconfdir}/tmpfiles.d/rabbitmq-server.conf
+        install -m 0644 ${UNPACKDIR}/rabbitmq-server-volatiles.conf ${D}${sysconfdir}/tmpfiles.d/rabbitmq-server.conf
     fi
 }
 

--- a/recipes-connectivity/vernemq/vernemq_1.13.0.bb
+++ b/recipes-connectivity/vernemq/vernemq_1.13.0.bb
@@ -50,41 +50,41 @@ export ERL_COMPILER_OPTIONS="deterministic"
 
 do_compile:prepend() {
     # fix dependency: eleveldb
-    install -D ${WORKDIR}/build_deps.sh.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/c_src/build_deps.sh
-    install -D ${WORKDIR}/Makefile.c_src.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/c_src/Makefile
-    install -D ${WORKDIR}/rebar.config.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/rebar.config
+    install -D ${UNPACKDIR}/build_deps.sh.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/c_src/build_deps.sh
+    install -D ${UNPACKDIR}/Makefile.c_src.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/c_src/Makefile
+    install -D ${UNPACKDIR}/rebar.config.eleveldb ${REBAR_BASE_DIR}/default/lib/eleveldb/rebar.config
 
     # fix dependency: bcrypt
-    install -D ${WORKDIR}/Makefile.c_src.bcrypt ${REBAR_BASE_DIR}/default/lib/bcrypt/c_src/Makefile
+    install -D ${UNPACKDIR}/Makefile.c_src.bcrypt ${REBAR_BASE_DIR}/default/lib/bcrypt/c_src/Makefile
 
     # fix dependency: vmq_passwd
-    install -D ${WORKDIR}/Makefile.c_src.vmq_passwd ${S}/apps/vmq_passwd/c_src/Makefile
+    install -D ${UNPACKDIR}/Makefile.c_src.vmq_passwd ${S}/apps/vmq_passwd/c_src/Makefile
 }
 
 do_install:prepend() {
     cd ${S}
-    cat ${WORKDIR}/vars.config > vars.generated
+    cat ${UNPACKDIR}/vars.config > vars.generated
     echo "{app_version, \"${PV}\"}." >> vars.generated
 }
 
 do_install:append() {
     install -d ${D}${sysconfdir}/vernemq
-    install -m 0644 ${WORKDIR}/vm.args ${D}${sysconfdir}/vernemq/vm.args
-    install -m 0644 ${WORKDIR}/vernemq.conf ${D}${sysconfdir}/vernemq/vernemq.conf
+    install -m 0644 ${UNPACKDIR}/vm.args ${D}${sysconfdir}/vernemq/vm.args
+    install -m 0644 ${UNPACKDIR}/vernemq.conf ${D}${sysconfdir}/vernemq/vernemq.conf
     chown -R vernemq.vernemq ${D}${sysconfdir}/vernemq
 
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/vernemq.service ${D}${systemd_unitdir}/system
+        install -m 0644 ${UNPACKDIR}/vernemq.service ${D}${systemd_unitdir}/system
         install -d ${D}${sysconfdir}/tmpfiles.d/
-        install -m 0644 ${WORKDIR}/vernemq-volatiles.conf ${D}${sysconfdir}/tmpfiles.d/vernemq.conf
+        install -m 0644 ${UNPACKDIR}/vernemq-volatiles.conf ${D}${sysconfdir}/tmpfiles.d/vernemq.conf
     fi
 
     if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
         install -d ${D}${sysconfdir}/init.d
-        install -m 0755 ${WORKDIR}/vernemq.init ${D}${sysconfdir}/init.d/vernemq
+        install -m 0755 ${UNPACKDIR}/vernemq.init ${D}${sysconfdir}/init.d/vernemq
         install -d ${D}${sysconfdir}/default/volatiles
-        install -m 0644 ${WORKDIR}/volatiles.99_vernemq ${D}${sysconfdir}/default/volatiles/99_vernemq
+        install -m 0644 ${UNPACKDIR}/volatiles.99_vernemq ${D}${sysconfdir}/default/volatiles/99_vernemq
     fi
 }
 

--- a/recipes-core/epmd/epmd.inc
+++ b/recipes-core/epmd/epmd.inc
@@ -53,13 +53,13 @@ do_compile() {
 do_install() {
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/epmd.service ${D}${systemd_system_unitdir}
-        install -m 0644 ${WORKDIR}/epmd.socket ${D}${systemd_system_unitdir}
+        install -m 0644 ${UNPACKDIR}/epmd.service ${D}${systemd_system_unitdir}
+        install -m 0644 ${UNPACKDIR}/epmd.socket ${D}${systemd_system_unitdir}
     fi
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'true', 'false', d)}; then
         install -d ${D}${sysconfdir}/init.d
-        install -m 0755 ${WORKDIR}/epmd.init ${D}${sysconfdir}/init.d/epmd
+        install -m 0755 ${UNPACKDIR}/epmd.init ${D}${sysconfdir}/init.d/epmd
     fi
 
     # get the correct triple, as we are not calling any make install rule

--- a/recipes-core/erlinit/erlinit_1.13.0.bb
+++ b/recipes-core/erlinit/erlinit_1.13.0.bb
@@ -20,7 +20,7 @@ do_install() {
         install -d 0755 ${D}/${base_sbindir}
         install -d 0755 ${D}/${sysconfdir}
 	install -m 0755 ${S}/erlinit ${D}/${base_sbindir}/init
-        install -m 0644 ${WORKDIR}/erlinit.config ${D}/${sysconfdir}/erlinit.config
+        install -m 0644 ${UNPACKDIR}/erlinit.config ${D}/${sysconfdir}/erlinit.config
 }
 
 FILES:${PN} = "${base_sbindir} ${sysconfdir}"

--- a/recipes-database/couchdb/couchdb.inc
+++ b/recipes-database/couchdb/couchdb.inc
@@ -66,14 +66,14 @@ do_install:append() {
     # Install systemd unit files
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/couchdb.service ${D}${systemd_unitdir}/system
+        install -m 0644 ${UNPACKDIR}/couchdb.service ${D}${systemd_unitdir}/system
         sed -i -e 's,%bindir%,/opt/couchdb/bin,g' \
 	       ${D}${systemd_unitdir}/system/couchdb.service
     fi
 
     # Install init.d
     if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
-        install -Dm 0755 ${WORKDIR}/couchdb.init ${D}/${sysconfdir}/init.d/couchdb
+        install -Dm 0755 ${UNPACKDIR}/couchdb.init ${D}/${sysconfdir}/init.d/couchdb
     fi
 }
 

--- a/recipes-database/riak/riak.inc
+++ b/recipes-database/riak/riak.inc
@@ -54,24 +54,24 @@ export ERL_COMPILER_OPTIONS="deterministic"
 
 do_compile:prepend() {
      # ebloom
-     install -D ${WORKDIR}/Makefile.c_src.ebloom ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/ebloom/c_src/Makefile
-     install -D ${WORKDIR}/rebar.config.ebloom ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/ebloom/rebar.config    
+     install -D ${UNPACKDIR}/Makefile.c_src.ebloom ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/ebloom/c_src/Makefile
+     install -D ${UNPACKDIR}/rebar.config.ebloom ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/ebloom/rebar.config    
      # bitcask
-     install -D ${WORKDIR}/Makefile.c_src.bitcask ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/bitcask/c_src/Makefile
-     install -D ${WORKDIR}/rebar.config.bitcask ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/bitcask/rebar.config
+     install -D ${UNPACKDIR}/Makefile.c_src.bitcask ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/bitcask/c_src/Makefile
+     install -D ${UNPACKDIR}/rebar.config.bitcask ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/bitcask/rebar.config
      # lz4
-     install -D ${WORKDIR}/Makefile.c_src.lz4 ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/lz4/c_src/Makefile
-     install -D ${WORKDIR}/rebar.config.lz4 ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/lz4/rebar.config
+     install -D ${UNPACKDIR}/Makefile.c_src.lz4 ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/lz4/c_src/Makefile
+     install -D ${UNPACKDIR}/rebar.config.lz4 ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/lz4/rebar.config
      # riak_ensemble
-    install -D ${WORKDIR}/Makefile.c_src.riak_ensemble ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/riak_ensemble/c_src/Makefile
-    install -D ${WORKDIR}/rebar.config.riak_ensemble ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/riak_ensemble/rebar.config
+    install -D ${UNPACKDIR}/Makefile.c_src.riak_ensemble ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/riak_ensemble/c_src/Makefile
+    install -D ${UNPACKDIR}/rebar.config.riak_ensemble ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/riak_ensemble/rebar.config
      # fix dependency: canola
-     install -D ${WORKDIR}/Makefile.c_src.canola ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/canola/c_src/Makefile
-     install -D ${WORKDIR}/rebar.config.canola ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/canola/rebar.config
+     install -D ${UNPACKDIR}/Makefile.c_src.canola ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/canola/c_src/Makefile
+     install -D ${UNPACKDIR}/rebar.config.canola ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/canola/rebar.config
      # fix dependency: eleveldb
-     install -D ${WORKDIR}/0001-Switch-to-shared-snappy-library-link.patch ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/eleveldb/c_src/0001-Switch-to-shared-snappy-library-link.patch
-     install -D ${WORKDIR}/Makefile.c_src.eleveldb ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/eleveldb/c_src/Makefile
-     install -D ${WORKDIR}/rebar.config.eleveldb ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/eleveldb/rebar.config
+     install -D ${UNPACKDIR}/0001-Switch-to-shared-snappy-library-link.patch ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/eleveldb/c_src/0001-Switch-to-shared-snappy-library-link.patch
+     install -D ${UNPACKDIR}/Makefile.c_src.eleveldb ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/eleveldb/c_src/Makefile
+     install -D ${UNPACKDIR}/rebar.config.eleveldb ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/eleveldb/rebar.config
 }
 
 do_install:append() {
@@ -79,10 +79,10 @@ do_install:append() {
     sed -i -e "s|^#!.*/bin/bash|#!/bin/sh|" ${erlang_release}/bin/hooks/builtin/wait_for_process
     
     # Install systemd unit files
-    install -Dm 0644 ${WORKDIR}/riak.service ${D}${systemd_unitdir}/system/riak.service
+    install -Dm 0644 ${UNPACKDIR}/riak.service ${D}${systemd_unitdir}/system/riak.service
 
     # Install init.d
-    install -Dm 0755 ${WORKDIR}/riak.init ${D}/${sysconfdir}/init.d/riak
+    install -Dm 0755 ${UNPACKDIR}/riak.init ${D}/${sysconfdir}/init.d/riak
 
     install -d ${erlang_release}/log
     chown -R riak.riak ${erlang_release}/log

--- a/recipes-devtools/elixir/elixir.inc
+++ b/recipes-devtools/elixir/elixir.inc
@@ -34,7 +34,7 @@ do_install() {
 
 do_install:prepend:class-nativesdk() {
     mkdir -p ${D}${SDKPATHNATIVE}/environment-setup.d
-    install -m 644 ${WORKDIR}/environment.d-elixir.sh ${D}${SDKPATHNATIVE}/environment-setup.d/elixir.sh
+    install -m 644 ${UNPACKDIR}/environment.d-elixir.sh ${D}${SDKPATHNATIVE}/environment-setup.d/elixir.sh
 }
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -128,9 +128,9 @@ do_install:prepend:class-nativesdk() {
 
     sed -i -e 's,@ERTS_VERSION@,${ERTS_VERSION},g' \
         -e 's,@ERL_INTERFACE_VERSION@,${ERL_INTERFACE_VERSION},g' \
-         ${WORKDIR}/environment.d-erlang.sh.in
+         ${UNPACKDIR}/environment.d-erlang.sh.in
     mkdir -p ${D}${SDKPATHNATIVE}/environment-setup.d
-    install -m 644 ${WORKDIR}/environment.d-erlang.sh.in ${D}${SDKPATHNATIVE}/environment-setup.d/erlang.sh
+    install -m 644 ${UNPACKDIR}/environment.d-erlang.sh.in ${D}${SDKPATHNATIVE}/environment-setup.d/erlang.sh
 }
 
 do_install:class-target() {
@@ -173,7 +173,7 @@ do_install:append:class-target() {
 }
 
 do_configure_ptest() {
-    xcomp=${WORKDIR}/erl-xcomp-oe.conf
+    xcomp=${UNPACKDIR}/erl-xcomp-oe.conf
     echo 'erl_xcomp_build=${BUILD_SYS}' > $xcomp
     echo 'erl_xcomp_host=${TARGET_SYS}' >> $xcomp
     echo 'erl_xcomp_configure_flags="--without-wx --enable-deterministic-build"' >> $xcomp
@@ -207,7 +207,7 @@ do_compile_ptest() {
     # need a full erlang build before call release_tests
     oe_runmake release_tests
     cd ${S}/release/tests/test_server
-    erl -noshell -eval 'ts:install([{xcomp, "${WORKDIR}/erl-xcomp-oe.conf"}])' -s ts compile_testcases -s init stop
+    erl -noshell -eval 'ts:install([{xcomp, "${UNPACKDIR}/erl-xcomp-oe.conf"}])' -s ts compile_testcases -s init stop
 }
 
 do_install_ptest() {

--- a/recipes-devtools/livebook/livebook_0.12.1.bb
+++ b/recipes-devtools/livebook/livebook_0.12.1.bb
@@ -25,15 +25,15 @@ inherit mix systemd useradd
 do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -d ${D}${sysconfdir}
-        install -m 0644 ${WORKDIR}/livebook.conf ${D}${sysconfdir}
+        install -m 0644 ${UNPACKDIR}/livebook.conf ${D}${sysconfdir}
         install -d ${D}${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/livebook.service ${D}${systemd_unitdir}/system
+        install -m 0644 ${UNPACKDIR}/livebook.service ${D}${systemd_unitdir}/system
     fi
 }
 
 do_install:append:class-nativesdk () {
     install -d ${D}${SDKPATHNATIVE}/environment-setup.d
-    install -m 644 ${WORKDIR}/environment.d-livebook.sh \
+    install -m 644 ${UNPACKDIR}/environment.d-livebook.sh \
         ${D}${SDKPATHNATIVE}/environment-setup.d/livebook.sh
 
     sed -i -e 's|^RELEASE_ROOT=.*|RELEASE_ROOT=${LIVEBOOK_OE_RELEASE_ROOT}|' \

--- a/recipes-devtools/rebar3/rebar3.inc
+++ b/recipes-devtools/rebar3/rebar3.inc
@@ -24,7 +24,7 @@ do_install() {
 
 do_install:append:class-nativesdk() {
     mkdir -p ${D}${SDKPATHNATIVE}/environment-setup.d
-    install -m 644 ${WORKDIR}/environment.d-rebar3.sh ${D}${SDKPATHNATIVE}/environment-setup.d/rebar3.sh
+    install -m 644 ${UNPACKDIR}/environment.d-rebar3.sh ${D}${SDKPATHNATIVE}/environment-setup.d/rebar3.sh
 }
 
 FILES:${PN} = "${bindir}/rebar3"

--- a/recipes-devtools/yanger/yanger_git.bb
+++ b/recipes-devtools/yanger/yanger_git.bb
@@ -28,7 +28,7 @@ do_compile() {
 do_install() {
     oe_runmake install DESTDIR=${D} PREFIX=${libdir}
     install -d ${D}${bindir}
-    install -m 0755 ${WORKDIR}/yanger.sh ${D}${bindir}/yanger
+    install -m 0755 ${UNPACKDIR}/yanger.sh ${D}${bindir}/yanger
 
     # install yanger wrapper to find the yanger installation path
     sed -i -e "s:%ROOTDIR%:${libdir}/yanger:g" ${D}${bindir}/yanger
@@ -37,7 +37,7 @@ do_install() {
 do_install:append:class-nativesdk() {
     # install environment setup to load yang modules
     mkdir -p ${D}${SDKPATHNATIVE}/environment-setup.d 
-    install -m 644 ${WORKDIR}/environment.d-yanger.sh ${D}${SDKPATHNATIVE}/environment-setup.d/yanger.sh
+    install -m 644 ${UNPACKDIR}/environment.d-yanger.sh ${D}${SDKPATHNATIVE}/environment-setup.d/yanger.sh
 }
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-examples/hello-http-server/hello-http-server_0.1.0.bb
+++ b/recipes-examples/hello-http-server/hello-http-server_0.1.0.bb
@@ -17,5 +17,5 @@ REBAR3_RELEASE = "${REBAR3_RELEASE_NAME}-0.1.0"
 
 # This is how we can `patch` files that were fetched by rebar3_do_configure()
 do_compile:prepend() {
-    install -D ${WORKDIR}/Makefile.c_src.bcrypt ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/bcrypt/c_src/Makefile
+    install -D ${UNPACKDIR}/Makefile.c_src.bcrypt ${REBAR_BASE_DIR}/${REBAR3_PROFILE}/lib/bcrypt/c_src/Makefile
 }

--- a/recipes-httpd/yaws/yaws_2.1.1.bb
+++ b/recipes-httpd/yaws/yaws_2.1.1.bb
@@ -70,11 +70,11 @@ do_install:append() {
 		${D}/${bindir}/yaws
 
 	# Install yaws.conf from this recipe
-	install ${WORKDIR}/yaws.conf ${D}/${sysconfdir}/yaws/yaws.conf
+	install ${UNPACKDIR}/yaws.conf ${D}/${sysconfdir}/yaws/yaws.conf
 	
 	# Install init.d
 	if ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'true', 'false', d)}; then
-		install ${WORKDIR}/yaws.init ${D}/${sysconfdir}/init.d/yaws
+		install ${UNPACKDIR}/yaws.init ${D}/${sysconfdir}/init.d/yaws
 	fi
 
         # Remove any volatile files


### PR DESCRIPTION
* UNPACKDIR is new contruct for do_unpack things in latest master we should be using that instead of WORKDIR for referencing those files.

* We don't know yet what changes will be needed to stay compatible with final styhead, but we already know that the last changes for UNPACKDIR aren't compatible with scarthgap, nanbield or others.

https://lists.openembedded.org/g/openembedded-architecture/message/2007
https://docs.yoctoproject.org/next/migration-guides/migration-5.1.html#workdir-changes