### PR TITLE
Add in elixir_1.16.3.bb from upstream

### DIFF
--- a/recipes-devtools/elixir/elixir_1.16.3.bb
+++ b/recipes-devtools/elixir/elixir_1.16.3.bb
@@ -1,0 +1,6 @@
+include elixir.inc
+
+SRCREV = "327063cc8485692f2b902553fb599a2bef5a0f8f"
+SRC_URI += "git://github.com/elixir-lang/elixir;branch=v1.16;protocol=https"
+
+PR = "r0"


### PR DESCRIPTION
Would be useful for anyone still using kirkstone but would like a 1.16.3 version of Elixir.