### PR TITLE
erlang: find config.h based on TARGET_SYS

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -82,7 +82,7 @@ do_configure:class-target() {
     sed -i -e 's@[^ ]*-fmacro-prefix-map=[^ "]*@@g' \
         -e 's@[^ ]*-fdebug-prefix-map=[^ "]*@@g' \
         -e 's@[^ ]*-I[^ "]*@@g' \
-        ${S}/erts/${TARGET_SYS}-gnu/config.h
+        ${S}/erts/${TARGET_SYS}*/config.h
 
     sed -i -e 's|$(ERL_TOP)/bin/dialyzer|${NATIVE_BIN}/dialyzer --output_plt $@ -pa $(ERL_TOP)/lib/kernel/ebin -pa $(ERL_TOP)/lib/stdlib/ebin|' lib/dialyzer/src/Makefile
 }


### PR DESCRIPTION
The prefix '-gnu' is only valid por x86 based builds. When ARM or other that prefix could be other.