### PR TITLE
riak: use features_check for pam dependency

### DIFF
--- a/recipes-database/riak/riak.inc
+++ b/recipes-database/riak/riak.inc
@@ -33,7 +33,9 @@ SRC_URI += " \
     file://Makefile.c_src.ebloom \
     file://rebar.config.ebloom"
 
-inherit rebar3-brokensep useradd systemd update-rc.d
+inherit rebar3-brokensep useradd systemd update-rc.d features_check
+
+REQUIRED_DISTRO_FEATURES = "pam"
 
 INITSCRIPT_NAME = "riak"
 INITSCRIPT_PARAMS = "defaults"


### PR DESCRIPTION
Fixes #339.