### PR TITLE
couchdb: bump to 3.4.2

### DIFF
--- a/recipes-database/couchdb/couchdb_3.4.2.bb
+++ b/recipes-database/couchdb/couchdb_3.4.2.bb
@@ -1,0 +1,131 @@
+DESCRIPTION = "CouchDB is a database that completely embraces the web. Store your data with JSON documents. \
+               Access your documents with your web browser, via HTTP. Query, combine, and transform your documents \
+               with JavaScript. CouchDB works well with modern web and mobile apps. You can distribute your data, \
+               efficiently using CouchDB’s incremental replication. CouchDB supports master-master setups with automatic \
+               conflict detection."
+SUMMARY = "A document-oriented NoSQL database"
+HOMEPAGE = "https://couchdb.apache.org/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5b7d1bad90e7a0de4d68a35df59116ca"
+
+SRC_URI = "git://github.com/apache/couchdb;protocol=https;branch=3.4.x \
+    file://0001-Fix-cross-compilation-environment-variables-and-use-.patch \
+    file://couchdb.service \
+    file://couchdb.init \
+"
+
+PV = "3.4.2+git${SRCPV}"
+SRCREV = "9295a0aa9ca01ad2254b0c5e245008749c8fcf64"
+
+S = "${WORKDIR}/git"
+
+PR = "r0"
+
+inherit autotools-brokensep pkgconfig erlang systemd update-rc.d useradd
+
+CONFIGUREOPTS = "--js-engine=quickjs --disable-spidermonkey --disable-docs \
+    --disable-fauxton \
+    --rebar ${STAGING_BINDIR_NATIVE}/rebar \
+    --rebar3 ${STAGING_BINDIR_NATIVE}/rebar3 \
+    --erlfmt ${STAGING_BINDIR_NATIVE}/erlfmt \
+"
+EXTRA_OECONF:remove = "--disable-static"
+
+export REBAR = "${STAGING_BINDIR_NATIVE}/rebar"
+export REBAR3 = "${STAGING_BINDIR_NATIVE}/rebar3"
+export ERLFMT = "${STAGING_BINDIR_NATIVE}/erlfmt"
+
+ERL_INTERFACE_VERSION = "`pkg-config --modversion erl_ei`"
+export ERL_CFLAGS = "`pkg-config --cflags-only-I erl_ei` -I${STAGING_LIBDIR}/erlang/usr/include"
+export ERL_EI_LIBDIR = "${STAGING_LIBDIR}/erlang/lib/erl_interface-${ERL_INTERFACE_VERSION}/lib/"
+
+LDFLAGS_ += "-L${STAGING_LIBDIR}/erlang/lib/erl_interface-${ERL_INTERFACE_VERSION}/lib"
+
+INITSCRIPT_NAME = "couchdb"
+INITSCRIPT_PARAMS = "defaults"
+
+SYSTEMD_SERVICE:${PN} = "couchdb.service"
+
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM:${PN} = "--system couchdb"
+USERADD_PARAM:${PN}  = "--system --create-home --home /var/lib/couchdb -g couchdb couchdb"
+
+export ERL_COMPILER_OPTIONS="deterministic"
+
+do_configure[network] = "1"
+
+do_configure:append:class-target() {
+    sed -i "s:-L/usr/local/lib:\$LDFLAGS:g" ${B}/src/couch/rebar.config.script
+
+    # include target erts
+    sed -i  "/{sys/ a {root_dir, \"${STAGING_LIBDIR}/erlang\"}," ${B}/rel/reltool.config
+    # exclude development static libraries
+    sed -i 's:"^erts.*/bin/(dialyzer|typer)":"^erts.*/bin/(dialyzer|typer)", "^erts.*/lib":g' ${B}/rel/reltool.config
+}
+
+do_install:append:class-target() {
+    install -d ${D}/opt
+    cp -r ${B}/rel/couchdb ${D}/opt/
+    chown -R couchdb:couchdb ${D}/opt/couchdb
+
+    # Remove tmp build path
+    sed -i -e "s,${B}/rel/couchdb,/opt/couchdb,g" \
+        ${D}/opt/couchdb/releases/RELEASES
+
+    # Cleanup installed filed (there are some build output files there)
+    rm -rf ${D}/opt/couchdb/lib/couch-${PV}/priv/couch_js
+    rm -rf ${D}/opt/couchdb/lib/couch-${PV}/priv/couch_ejson_compare
+
+    install -d ${D}/var/lib/couchdb
+
+    # Install systemd unit files
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system
+        install -m 0644 ${WORKDIR}/couchdb.service ${D}${systemd_unitdir}/system
+        sed -i -e 's,%bindir%,/opt/couchdb/bin,g' \
+	       ${D}${systemd_unitdir}/system/couchdb.service
+    fi
+
+    # Install init.d
+    if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
+        install -Dm 0755 ${WORKDIR}/couchdb.init ${D}/${sysconfdir}/init.d/couchdb
+    fi
+
+    # Cleanup, couchdb build is leaking something else
+    find ${D}/opt -type f -name "couch_ejson_compare.[d,o]" -delete
+}
+
+do_configure:class-native() {
+	:
+}
+
+do_compile:class-native() {
+	oe_runmake -C ${S}/src/couch_quickjs/quickjs qjsc
+}
+
+do_install:class-native() {
+    install -d ${D}/${bindir}
+    install -m755 ${S}/src/couch_quickjs/quickjs/qjsc ${D}/${bindir}
+}
+
+FILES:${PN} += " \
+    /etc \
+    /opt/couchdb \
+    /var/lib/couchdb \
+"
+
+DEPENDS:class-target += " \
+    curl \
+    erlang \
+    erlang-native \
+    icu \
+    openssl \
+    rebar-native \
+    rebar3-native \
+    erlfmt-native \
+    couchdb-native \
+"
+
+INSANE_SKIP:${PN} = "already-stripped"
+
+BBCLASSEXTEND = "native"

--- a/recipes-database/couchdb/files/0001-Fix-cross-compilation-environment-variables-and-use-.patch
+++ b/recipes-database/couchdb/files/0001-Fix-cross-compilation-environment-variables-and-use-.patch
@@ -1,0 +1,66 @@
+From 88682ffa1c62afd89aee4a05cddc492b9b287ea9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jo=C3=A3o=20Henrique=20Ferreira=20de=20Freitas?=
+ <joaohf@gmail.com>
+Date: Mon, 10 Mar 2025 11:41:39 -0300
+Subject: [PATCH] Fix cross compilation environment variables and use
+ quickjs-native
+
+Upstream-Status: Inappropriate [OE-Specific]
+---
+ src/couch_quickjs/build_js.escript |  4 +---
+ src/couch_quickjs/quickjs/Makefile | 10 +++++-----
+ 2 files changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/src/couch_quickjs/build_js.escript b/src/couch_quickjs/build_js.escript
+index 1da48ee87..6cf90cc4c 100644
+--- a/src/couch_quickjs/build_js.escript
++++ b/src/couch_quickjs/build_js.escript
+@@ -72,9 +72,7 @@ concat_js_files(JsScript, CoffeeScript) ->
+ compile_bytecode(Js, CBytecode) ->
+     % cp_if_different/2 is used to to avoid triggering a re-compile if nothing changed
+     Tmp = CBytecode ++ ".tmp",
+-    {ok, Cwd} = file:get_cwd(),
+-    CompileCmd = Cwd ++ "/quickjs/qjsc -c -N bytecode -o c_src/" ++ Tmp ++ " priv/" ++ Js,
+-    os:cmd(CompileCmd),
++    os:cmd("qjsc -c -N bytecode -o c_src/" ++ Tmp ++ " priv/" ++ Js),
+     Changed = cp_if_different("c_src/" ++ Tmp, "c_src/" ++ CBytecode),
+     rm("c_src/" ++ Tmp),
+     Changed.
+diff --git a/src/couch_quickjs/quickjs/Makefile b/src/couch_quickjs/quickjs/Makefile
+index cf88a723a..051d2657f 100644
+--- a/src/couch_quickjs/quickjs/Makefile
++++ b/src/couch_quickjs/quickjs/Makefile
+@@ -122,13 +122,13 @@ else ifdef CONFIG_COSMO
+   AR=cosmoar
+ else
+   HOST_CC=gcc
+-  CC=$(CROSS_PREFIX)gcc
++  CC?=$(CROSS_PREFIX)gcc
+   CFLAGS+=-g -Wall -MMD -MF $(OBJDIR)/$(@F).d
+   CFLAGS += -Wno-array-bounds -Wno-format-truncation
+   ifdef CONFIG_LTO
+-    AR=$(CROSS_PREFIX)gcc-ar
++    AR?=$(CROSS_PREFIX)gcc-ar
+   else
+-    AR=$(CROSS_PREFIX)ar
++    AR?=$(CROSS_PREFIX)ar
+   endif
+ endif
+ STRIP?=$(CROSS_PREFIX)strip
+@@ -273,11 +273,11 @@ $(QJSC): $(OBJDIR)/qjsc.host.o \
+ 
+ endif #CROSS_PREFIX
+ 
+-QJSC_DEFINES:=-DCONFIG_CC=\"$(QJSC_CC)\" -DCONFIG_PREFIX=\"$(PREFIX)\"
++#QJSC_DEFINES:=-DCONFIG_CC="zz" -DCONFIG_PREFIX=\"$(PREFIX)\"
+ ifdef CONFIG_LTO
+ QJSC_DEFINES+=-DCONFIG_LTO
+ endif
+-QJSC_HOST_DEFINES:=-DCONFIG_CC=\"$(HOST_CC)\" -DCONFIG_PREFIX=\"$(PREFIX)\"
++#QJSC_HOST_DEFINES:=-DCONFIG_CC="zz" -DCONFIG_PREFIX=\"$(PREFIX)\"
+ 
+ $(OBJDIR)/qjsc.o: CFLAGS+=$(QJSC_DEFINES)
+ $(OBJDIR)/qjsc.host.o: CFLAGS+=$(QJSC_HOST_DEFINES)
+-- 
+2.43.0
+

--- a/recipes-database/couchdb/files/couchdb.init
+++ b/recipes-database/couchdb/files/couchdb.init
@@ -1,0 +1,73 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          couchdb
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts Couchdb server
+# Description:       Starts Couchdb server, a document-oriented
+#                    NoSQL database
+### END INIT INFO
+
+DAEMON=/opt/couchdb/bin/couchdb
+NAME=couchdb
+DESC="Couchdb server"
+DAEMON_OPTS=""
+
+test -x $DAEMON || exit 0
+
+PIDFILE=/var/run/couchdb.pid
+
+# Source function library.
+. /etc/init.d/functions
+
+start()
+{
+    start-stop-daemon --quiet --make-pidfile --pidfile $PIDFILE --background --exec $DAEMON --start -- \
+        $DAEMON_OPTS
+}
+
+stop()
+{
+    start-stop-daemon --stop --quiet --pidfile $PIDFILE
+}
+
+case "$1" in
+    start)
+        echo "Starting $DESC" "$NAME"
+        start
+        echo $?
+        ;;
+    stop)
+        echo "Stopping $DESC" "$NAME"
+        stop
+        echo $?
+        ;;
+    status)
+        start-stop-daemon --stop --test --pidfile $PIDFILE > /dev/null 2>&1
+        if [ 0 -eq $? ]; then
+            echo "$NAME is running..."
+        else
+            echo "$NAME is stopped"
+        fi
+        ;;
+    reload|force-reload)
+	stop
+	start
+        ;;
+    restart)
+        echo "Restarting $DESC" "$NAME"
+        stop
+        start
+        echo $?
+        ;;
+    *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|status|restart|reload|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/recipes-database/couchdb/files/couchdb.service
+++ b/recipes-database/couchdb/files/couchdb.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Apache CouchDB
+Wants=network-online.target
+After=network-online.target remote-fs.target
+
+[Service]
+User=couchdb
+Group=couchdb
+
+ExecStart=%bindir%/couchdb -o /dev/stdout -e /dev/stderr
+
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-devtools/rebar/rebar_git.bb
+++ b/recipes-devtools/rebar/rebar_git.bb
@@ -4,11 +4,11 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ff253ad767462c46be284da12dda33e8"
 
 S = "${WORKDIR}/git"
-SRCREV = "b6d309417c502ca243f810e5313bea36951ef038"
-PV = "2.6.4+git${SRCPV}"
-PR = "r1"
+SRCREV = "9e60c709fdf759b614ab1441f36f51936bb5bbd4"
+PV = "2.6.2-1+git${SRCPV}"
+PR = "r2"
 
-SRC_URI = "git://github.com/rebar/rebar;branch=master;protocol=https"
+SRC_URI = "git://github.com/apache/couchdb-rebar;branch=main;protocol=https"
 
 DEPENDS += "erlang-native"
 


### PR DESCRIPTION
Use quickjs [1] instead mozjs.

mozjs-91 does not support python 3.12.x, thus couchdb for meta-erlang can't usemozjs-91 anymore.

1: https://github.com/apache/couchdb/issues/4448