### PR TITLE
erlang: allow build nativesdk-erlang without opengl support

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -33,13 +33,23 @@ inherit ptest autotools-brokensep pkgconfig
 
 PACKAGECONFIG ?= "pkgconfig zlib termcap"
 PACKAGECONFIG:class-native ?= "pkgconfig"
-PACKAGECONFIG:class-nativesdk ?= "pkgconfig wx observer termcap"
+# For nativesdk, check if opengl is available before including: wx, observer, et, debugger
+# as these application depends on wx and it will not be build without opengl support.
+#
+# reltool is also an erlang application which uses wx. However reltool does not depend
+# on wx_object behavior, so, it's safe (no graphic interface available, only batch mode)
+# to allow reltool for nativesdk. For the rest (observer, et and debugger) which use wx_object
+# it is safer to remove them from nativesdk support.
+PACKAGECONFIG:class-nativesdk ?= "pkgconfig termcap \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'wx observer et debugger', '', d)}"
 PACKAGECONFIG[zlib] = "--disable-builtin-zlib,--enable-builtin-zlib,zlib"
 PACKAGECONFIG[termcap] = "--with-termcap,--without-termcap,ncurses"
 PACKAGECONFIG[odbc] = "--with-odbc,--without-odbc,libodbc"
 PACKAGECONFIG[lttng] = "--with-dynamic-trace=lttng,--without-dynamic-trace,lttng-ust"
-PACKAGECONFIG[wx] = "--with-wx,,wxwidgets"
-PACKAGECONFIG[observer] = "--with-observer,--without-observer,wxwidgets,"
+PACKAGECONFIG[wx] = "--with-wx,--without-wx,wxwidgets"
+PACKAGECONFIG[observer] = "--with-observer,--without-observer,,"
+PACKAGECONFIG[et] = "--with-et,--without-et,,"
+PACKAGECONFIG[debugger] = "--with-debugger,--without-debugger,,"
 PACKAGECONFIG[sctp] = ",,,lksctp-tools"
 PACKAGECONFIG[java] = ",--without-javac,,"
 PACKAGECONFIG[pkgconfig] = "--enable-pkg-config,,,"

--- a/recipes-devtools/erlang/erlang_25.3.2.21.bb
+++ b/recipes-devtools/erlang/erlang_25.3.2.21.bb
@@ -5,6 +5,7 @@ PR = "r0"
 
 SRC_URI += "file://0001-Fix-for-Werror-format-security.patch"
 SRC_URI += "file://pr-gh-7952-Fix-build-on-Yocto.patch"
+SRC_URI += "file://0001-Add-missing-wx-dependencies.patch"
 
 SRCREV = "52199ed7e79646b73bacc47c92967ce9970b2373"
 

--- a/recipes-devtools/erlang/erlang_26.2.5.15.bb
+++ b/recipes-devtools/erlang/erlang_26.2.5.15.bb
@@ -5,6 +5,7 @@ PR = "r0"
 
 SRC_URI += "file://0001-Fix-for-Werror-format-security.patch"
 SRC_URI += "file://pr-gh-7952-Fix-build-on-Yocto.patch"
+SRC_URI += "file://0001-Add-missing-wx-dependencies.patch"
 
 SRCREV = "4d9b61940e8d4dd00059306983022e3114fdf245"
 

--- a/recipes-devtools/erlang/erlang_27.3.4.3.bb
+++ b/recipes-devtools/erlang/erlang_27.3.4.3.bb
@@ -4,7 +4,8 @@ require erlang-${PV}-manifest.inc
 PR = "r0"
 
 SRC_URI += "file://0001-Enable-x32-support-for-crypto-configure.patch \
-            file://0002-Enable-the-correct-ifdef-branch-when-x32-is-enabled.patch"
+            file://0002-Enable-the-correct-ifdef-branch-when-x32-is-enabled.patch \
+            file://0001-Add-missing-wx-dependencies.patch"
 
 SRCREV = "940ec0f6f0370ecf5cd93cae31fd91f4651ddca6"
 

--- a/recipes-devtools/erlang/files/25/0001-Add-missing-wx-dependencies.patch
+++ b/recipes-devtools/erlang/files/25/0001-Add-missing-wx-dependencies.patch
@@ -1,0 +1,150 @@
+From 3973a45065785ce211bf3347aa6625f2f13c2967 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jo=C3=A3o=20Henrique=20Ferreira=20de=20Freitas?=
+ <joaohf@gmail.com>
+Date: Tue, 8 Apr 2025 17:23:25 -0300
+Subject: [PATCH] Add missing wx dependencies
+
+The following applications:
+
+ - et
+ - observer
+ - debugger
+ - reltool
+
+And also the wx/examples/[simple,demo,sudoku] depends on wx application
+in order to build properly.
+
+When cross compiling Erlang/OTP [1], there are cases where the initial
+bootstrap system (which in most of the cases is just the same Erlang/OTP
+version but built for host) may not have Erlang wx application enabled.
+Thus when cross compiling the above applications will not able to found
+wx.hrl and wx behaviour files.
+
+That is because the target build should look into ERL_TOP in order to
+see the missing dependencies.
+
+Without the proper ERL_COMPILE_FLAGS the build will try to use from the
+host system, which in my case does not have wx enabled.
+
+1: https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-CROSS.md
+
+Upstream-Status: Submitted [https://github.com/erlang/otp/pull/9708]
+---
+ lib/debugger/src/Makefile       | 2 +-
+ lib/dialyzer/src/Makefile       | 1 +
+ lib/et/src/Makefile             | 6 +++++-
+ lib/observer/src/Makefile       | 2 ++
+ lib/reltool/src/Makefile        | 3 ++-
+ lib/wx/examples/demo/Makefile   | 2 ++
+ lib/wx/examples/simple/Makefile | 2 ++
+ lib/wx/examples/sudoku/Makefile | 2 ++
+ 8 files changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/lib/debugger/src/Makefile b/lib/debugger/src/Makefile
+index 2fb955b2e3..4c4773fb5a 100644
+--- a/lib/debugger/src/Makefile
++++ b/lib/debugger/src/Makefile
+@@ -85,7 +85,7 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ # ----------------------------------------------------
+ # FLAGS
+ # ----------------------------------------------------
+-ERL_COMPILE_FLAGS += -Werror
++ERL_COMPILE_FLAGS += -Werror -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
+ 
+ 
+ # ----------------------------------------------------
+diff --git a/lib/dialyzer/src/Makefile b/lib/dialyzer/src/Makefile
+index c934ecdc2b..703c6b83ad 100644
+--- a/lib/dialyzer/src/Makefile
++++ b/lib/dialyzer/src/Makefile
+@@ -95,6 +95,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
+ 
+ ERL_COMPILE_FLAGS += -Werror
+ ERL_COMPILE_FLAGS += +warn_export_vars +warn_unused_import +warn_missing_spec
++ERL_COMPILE_FLAGS += -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
+ 
+ # ----------------------------------------------------
+ # Targets
+diff --git a/lib/et/src/Makefile b/lib/et/src/Makefile
+index fc66cc1eaf..ed3a2ff712 100644
+--- a/lib/et/src/Makefile
++++ b/lib/et/src/Makefile
+@@ -66,7 +66,11 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ # ----------------------------------------------------
+ # FLAGS
+ # ----------------------------------------------------
+-ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/et/ebin -I../include -Werror
++ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/et/ebin \
++		     -pa $(ERL_TOP)/lib/wx/ebin \
++		     -I../include \
++		     -I $(ERL_TOP)/lib \
++		     -Werror
+ 
+ # ----------------------------------------------------
+ # Special Build Targets
+diff --git a/lib/observer/src/Makefile b/lib/observer/src/Makefile
+index 2edb2ceb3e..3c5bc74c36 100644
+--- a/lib/observer/src/Makefile
++++ b/lib/observer/src/Makefile
+@@ -123,6 +123,8 @@ ERL_COMPILE_FLAGS += \
+ 	-I../include \
+ 	-I ../../et/include \
+ 	-I ../../../libraries/et/include \
++	-I $(ERL_TOP)/lib \
++	-pa $(ERL_TOP)/lib/wx/ebin \
+ 	-Werror
+ 
+ # ----------------------------------------------------
+diff --git a/lib/reltool/src/Makefile b/lib/reltool/src/Makefile
+index 173a557d58..110663a1de 100644
+--- a/lib/reltool/src/Makefile
++++ b/lib/reltool/src/Makefile
+@@ -59,7 +59,8 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ 
+ ERL_COMPILE_FLAGS += +'{parse_transform,sys_pre_attributes}' \
+                      +'{attribute,insert,app_vsn,$(APP_VSN)}' \
+-		     -Werror
++		     -Werror \
++		     -I $(ERL_TOP)/lib
+ 
+ # ----------------------------------------------------
+ # Targets
+diff --git a/lib/wx/examples/demo/Makefile b/lib/wx/examples/demo/Makefile
+index 123c54580f..e18b3ce819 100644
+--- a/lib/wx/examples/demo/Makefile
++++ b/lib/wx/examples/demo/Makefile
+@@ -61,6 +61,8 @@ TESTMODS = \
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
++ERL_COMPILE_FLAGS += -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
++
+ # Targets
+ $(TYPES):	$(TESTTARGETS)
+ clean:
+diff --git a/lib/wx/examples/simple/Makefile b/lib/wx/examples/simple/Makefile
+index 16ac01d40d..3725c39ede 100644
+--- a/lib/wx/examples/simple/Makefile
++++ b/lib/wx/examples/simple/Makefile
+@@ -30,6 +30,8 @@ TESTMODS = hello hello2 minimal menu
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
++ERL_COMPILE_FLAGS += -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
++
+ # Targets
+ $(TYPES):	$(TESTTARGETS)
+ clean:
+diff --git a/lib/wx/examples/sudoku/Makefile b/lib/wx/examples/sudoku/Makefile
+index ccdcb7cd9f..9e29d1c344 100644
+--- a/lib/wx/examples/sudoku/Makefile
++++ b/lib/wx/examples/sudoku/Makefile
+@@ -30,6 +30,8 @@ TESTMODS = sudoku sudoku_board sudoku_game sudoku_gui
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
++ERL_COMPILE_FLAGS += -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
++
+ # Targets
+ $(TYPES):	$(TESTTARGETS)
+ clean:

--- a/recipes-devtools/erlang/files/26/0001-Add-missing-wx-dependencies.patch
+++ b/recipes-devtools/erlang/files/26/0001-Add-missing-wx-dependencies.patch
@@ -1,0 +1,153 @@
+From efbe58a62c69b802b2ce2541a33bb0fa3ce5a1c2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jo=C3=A3o=20Henrique=20Ferreira=20de=20Freitas?=
+ <joaohf@gmail.com>
+Date: Tue, 8 Apr 2025 17:23:25 -0300
+Subject: [PATCH] Add missing wx dependencies
+
+The following applications:
+
+ - et
+ - observer
+ - debugger
+ - reltool
+
+And also the wx/examples/[simple,demo,sudoku] depends on wx application
+in order to build properly.
+
+When cross compiling Erlang/OTP [1], there are cases where the initial
+bootstrap system (which in most of the cases is just the same Erlang/OTP
+version but built for host) may not have Erlang wx application enabled.
+Thus when cross compiling the above applications will not able to found
+wx.hrl and wx behaviour files.
+
+That is because the target build should look into ERL_TOP in order to
+see the missing dependencies.
+
+Without the proper ERL_COMPILE_FLAGS the build will try to use from the
+host system, which in my case does not have wx enabled.
+
+1: https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-CROSS.md
+
+Upstream-Status: Submitted [https://github.com/erlang/otp/pull/9708]
+---
+ lib/debugger/src/Makefile       | 2 +-
+ lib/dialyzer/src/Makefile       | 1 +
+ lib/et/src/Makefile             | 6 +++++-
+ lib/observer/src/Makefile       | 2 ++
+ lib/reltool/src/Makefile        | 3 ++-
+ lib/wx/examples/demo/Makefile   | 2 ++
+ lib/wx/examples/simple/Makefile | 2 ++
+ lib/wx/examples/sudoku/Makefile | 2 ++
+ 8 files changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/lib/debugger/src/Makefile b/lib/debugger/src/Makefile
+index 2fb955b2e3..4c4773fb5a 100644
+--- a/lib/debugger/src/Makefile
++++ b/lib/debugger/src/Makefile
+@@ -85,7 +85,7 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ # ----------------------------------------------------
+ # FLAGS
+ # ----------------------------------------------------
+-ERL_COMPILE_FLAGS += -Werror
++ERL_COMPILE_FLAGS += -Werror -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
+ 
+ 
+ # ----------------------------------------------------
+diff --git a/lib/dialyzer/src/Makefile b/lib/dialyzer/src/Makefile
+index 2f0f1f6b71..20898e93f3 100644
+--- a/lib/dialyzer/src/Makefile
++++ b/lib/dialyzer/src/Makefile
+@@ -98,6 +98,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
+ 
+ ERL_COMPILE_FLAGS += -Werror
+ ERL_COMPILE_FLAGS += +warn_export_vars +warn_unused_import +warn_missing_spec
++ERL_COMPILE_FLAGS += -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
+ 
+ # ----------------------------------------------------
+ # Targets
+diff --git a/lib/et/src/Makefile b/lib/et/src/Makefile
+index fc66cc1eaf..ed3a2ff712 100644
+--- a/lib/et/src/Makefile
++++ b/lib/et/src/Makefile
+@@ -66,7 +66,11 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ # ----------------------------------------------------
+ # FLAGS
+ # ----------------------------------------------------
+-ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/et/ebin -I../include -Werror
++ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/et/ebin \
++		     -pa $(ERL_TOP)/lib/wx/ebin \
++		     -I../include \
++		     -I $(ERL_TOP)/lib \
++		     -Werror
+ 
+ # ----------------------------------------------------
+ # Special Build Targets
+diff --git a/lib/observer/src/Makefile b/lib/observer/src/Makefile
+index 2edb2ceb3e..3c5bc74c36 100644
+--- a/lib/observer/src/Makefile
++++ b/lib/observer/src/Makefile
+@@ -123,6 +123,8 @@ ERL_COMPILE_FLAGS += \
+ 	-I../include \
+ 	-I ../../et/include \
+ 	-I ../../../libraries/et/include \
++	-I $(ERL_TOP)/lib \
++	-pa $(ERL_TOP)/lib/wx/ebin \
+ 	-Werror
+ 
+ # ----------------------------------------------------
+diff --git a/lib/reltool/src/Makefile b/lib/reltool/src/Makefile
+index 173a557d58..110663a1de 100644
+--- a/lib/reltool/src/Makefile
++++ b/lib/reltool/src/Makefile
+@@ -59,7 +59,8 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ 
+ ERL_COMPILE_FLAGS += +'{parse_transform,sys_pre_attributes}' \
+                      +'{attribute,insert,app_vsn,$(APP_VSN)}' \
+-		     -Werror
++		     -Werror \
++		     -I $(ERL_TOP)/lib
+ 
+ # ----------------------------------------------------
+ # Targets
+diff --git a/lib/wx/examples/demo/Makefile b/lib/wx/examples/demo/Makefile
+index 123c54580f..e18b3ce819 100644
+--- a/lib/wx/examples/demo/Makefile
++++ b/lib/wx/examples/demo/Makefile
+@@ -61,6 +61,8 @@ TESTMODS = \
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
++ERL_COMPILE_FLAGS += -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
++
+ # Targets
+ $(TYPES):	$(TESTTARGETS)
+ clean:
+diff --git a/lib/wx/examples/simple/Makefile b/lib/wx/examples/simple/Makefile
+index 16ac01d40d..3725c39ede 100644
+--- a/lib/wx/examples/simple/Makefile
++++ b/lib/wx/examples/simple/Makefile
+@@ -30,6 +30,8 @@ TESTMODS = hello hello2 minimal menu
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
++ERL_COMPILE_FLAGS += -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
++
+ # Targets
+ $(TYPES):	$(TESTTARGETS)
+ clean:
+diff --git a/lib/wx/examples/sudoku/Makefile b/lib/wx/examples/sudoku/Makefile
+index ccdcb7cd9f..9e29d1c344 100644
+--- a/lib/wx/examples/sudoku/Makefile
++++ b/lib/wx/examples/sudoku/Makefile
+@@ -30,6 +30,8 @@ TESTMODS = sudoku sudoku_board sudoku_game sudoku_gui
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
++ERL_COMPILE_FLAGS += -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
++
+ # Targets
+ $(TYPES):	$(TESTTARGETS)
+ clean:
+-- 
+2.43.0
+

--- a/recipes-devtools/erlang/files/27/0001-Add-missing-wx-dependencies.patch
+++ b/recipes-devtools/erlang/files/27/0001-Add-missing-wx-dependencies.patch
@@ -1,0 +1,140 @@
+From d523f574fb5a9d723568f54ddeafb0a192cb2c6f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jo=C3=A3o=20Henrique=20Ferreira=20de=20Freitas?=
+ <joaohf@gmail.com>
+Date: Tue, 8 Apr 2025 17:23:25 -0300
+Subject: [PATCH] Add missing wx dependencies
+
+The following applications:
+
+ - et
+ - observer
+ - debugger
+ - reltool
+
+And also the wx/examples/[simple,demo,sudoku] depends on wx application
+in order to build properly.
+
+When cross compiling Erlang/OTP [1], there are cases where the initial
+bootstrap system (which in most of the cases is just the same Erlang/OTP
+version but built for host) may not have Erlang wx application enabled.
+Thus when cross compiling the above applications will not able to found
+wx.hrl and wx behaviour files.
+
+That is because the target build should look into ERL_TOP in order to
+see the missing dependencies.
+
+Without the proper ERL_COMPILE_FLAGS the build will try to use from the
+host system, which in my case does not have wx enabled.
+
+1: https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-CROSS.md
+
+Upstream-Status: Submitted [https://github.com/erlang/otp/pull/9708]
+---
+ lib/debugger/src/Makefile       | 2 +-
+ lib/et/src/Makefile             | 6 +++++-
+ lib/observer/src/Makefile       | 2 ++
+ lib/reltool/src/Makefile        | 3 ++-
+ lib/wx/examples/demo/Makefile   | 3 ++-
+ lib/wx/examples/simple/Makefile | 3 ++-
+ lib/wx/examples/sudoku/Makefile | 3 ++-
+ 7 files changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/lib/debugger/src/Makefile b/lib/debugger/src/Makefile
+index 2fb955b2e3..4c4773fb5a 100644
+--- a/lib/debugger/src/Makefile
++++ b/lib/debugger/src/Makefile
+@@ -85,7 +85,7 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ # ----------------------------------------------------
+ # FLAGS
+ # ----------------------------------------------------
+-ERL_COMPILE_FLAGS += -Werror
++ERL_COMPILE_FLAGS += -Werror -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
+ 
+ 
+ # ----------------------------------------------------
+diff --git a/lib/et/src/Makefile b/lib/et/src/Makefile
+index fc66cc1eaf..ed3a2ff712 100644
+--- a/lib/et/src/Makefile
++++ b/lib/et/src/Makefile
+@@ -66,7 +66,11 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ # ----------------------------------------------------
+ # FLAGS
+ # ----------------------------------------------------
+-ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/et/ebin -I../include -Werror
++ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/et/ebin \
++		     -pa $(ERL_TOP)/lib/wx/ebin \
++		     -I../include \
++		     -I $(ERL_TOP)/lib \
++		     -Werror
+ 
+ # ----------------------------------------------------
+ # Special Build Targets
+diff --git a/lib/observer/src/Makefile b/lib/observer/src/Makefile
+index 2edb2ceb3e..3c5bc74c36 100644
+--- a/lib/observer/src/Makefile
++++ b/lib/observer/src/Makefile
+@@ -123,6 +123,8 @@ ERL_COMPILE_FLAGS += \
+ 	-I../include \
+ 	-I ../../et/include \
+ 	-I ../../../libraries/et/include \
++	-I $(ERL_TOP)/lib \
++	-pa $(ERL_TOP)/lib/wx/ebin \
+ 	-Werror
+ 
+ # ----------------------------------------------------
+diff --git a/lib/reltool/src/Makefile b/lib/reltool/src/Makefile
+index 173a557d58..110663a1de 100644
+--- a/lib/reltool/src/Makefile
++++ b/lib/reltool/src/Makefile
+@@ -59,7 +59,8 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
+ 
+ ERL_COMPILE_FLAGS += +'{parse_transform,sys_pre_attributes}' \
+                      +'{attribute,insert,app_vsn,$(APP_VSN)}' \
+-		     -Werror
++		     -Werror \
++		     -I $(ERL_TOP)/lib
+ 
+ # ----------------------------------------------------
+ # Targets
+diff --git a/lib/wx/examples/demo/Makefile b/lib/wx/examples/demo/Makefile
+index 9f0367f7cf..e76ab97a7e 100644
+--- a/lib/wx/examples/demo/Makefile
++++ b/lib/wx/examples/demo/Makefile
+@@ -61,7 +61,8 @@ TESTMODS = \
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
+-ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented
++ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented \
++		     -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
+ 
+ # Targets
+ $(TYPES):	$(TESTTARGETS)
+diff --git a/lib/wx/examples/simple/Makefile b/lib/wx/examples/simple/Makefile
+index 73ef477fc5..8e93504741 100644
+--- a/lib/wx/examples/simple/Makefile
++++ b/lib/wx/examples/simple/Makefile
+@@ -30,7 +30,8 @@ TESTMODS = hello hello2 minimal menu
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
+-ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented
++ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented \
++		     -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
+ 
+ # Targets
+ $(TYPES):	$(TESTTARGETS)
+diff --git a/lib/wx/examples/sudoku/Makefile b/lib/wx/examples/sudoku/Makefile
+index 089ad34fb2..a51bf51146 100644
+--- a/lib/wx/examples/sudoku/Makefile
++++ b/lib/wx/examples/sudoku/Makefile
+@@ -30,7 +30,8 @@ TESTMODS = sudoku sudoku_board sudoku_game sudoku_gui
+ TESTTARGETS = $(TESTMODS:%=%.beam)
+ TESTSRC = $(TESTMODS:%=%.erl)
+ 
+-ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented
++ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented \
++		     -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
+ 
+ # Targets
+ $(TYPES):	$(TESTTARGETS)


### PR DESCRIPTION
By default, PACKAGECONFIG for nativesdk includes wx, observer, et, debugger if opengl is available in DISTRO_FEATURES variable.

The wx application for Erlang/OTP does not support building without opengl. Thus some applications will not work (or even build) without wx: observer, et, debugger. And it's valid to configure PACKAGECONFIG variable erlang recipe for nativesdk without the mentioned applications.

One could remove opengl feature when building nativesdk. I recommend to use the variable:

DISTRO_FEATURES_FILTER_NATIVESDK:remove = "opengl"

To make sure that opengl will not be present in final DISTRO_FEATURES variable for nativesdk.

Also, I had to apply a patch that fixes missing dependencies for wx. That patch is important, otherwise, applications will not build correctly.

Fixes #366