### PR TITLE
Move to wrynose

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 BBFILE_COLLECTIONS += "erlang-layer"
 BBFILE_PATTERN_erlang-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_erlang-layer = "7"
-LAYERSERIES_COMPAT_erlang-layer = "whinlatter"
+LAYERSERIES_COMPAT_erlang-layer = "wrynose"
 
 LAYERDEPENDS_erlang-layer = "core"
 


### PR DESCRIPTION
This change ensures compatibility with recent OE-Core releases that use the "wrynose" series name.