### PR TITLE
rabbitmq-server: force serial build to fix intermittent build failures

### DIFF
--- a/recipes-connectivity/rabbitmq/rabbitmq-server_3.11.28.bb
+++ b/recipes-connectivity/rabbitmq/rabbitmq-server_3.11.28.bb
@@ -56,7 +56,7 @@ do_fix_deps () {
 do_compile() {
     export PYTHON=python3
 
-    oe_runmake
+    oe_runmake -j1
 }
 
 do_install() {

--- a/recipes-connectivity/rabbitmq/rabbitmq-server_3.13.7.bb
+++ b/recipes-connectivity/rabbitmq/rabbitmq-server_3.13.7.bb
@@ -56,7 +56,7 @@ do_fix_deps () {
 do_compile() {
     export PYTHON=python3
 
-    oe_runmake
+    oe_runmake -j1
 }
 
 do_install() {


### PR DESCRIPTION
Disable parallel make during compile to avoid race-related build errors seen in dependency generation and escript steps.