### PR TITLE
meta-erlang-toolchain: Fix NameError by adding missing oe.utils prefix

### DIFF
--- a/recipes-core/meta/meta-erlang-toolchain.bb
+++ b/recipes-core/meta/meta-erlang-toolchain.bb
@@ -14,7 +14,7 @@ TOOLCHAIN_HOST_TASK:append = " \
 "
 
 TOOLCHAIN_TARGET_TASK:append = " \
-    ${@multilib_pkg_extend(d, 'packagegroup-erlang-sdk-target')} \
+    ${@oe.utils.multilib_pkg_extend(d, 'packagegroup-erlang-sdk-target')} \
 "
 
 SDK_TITLE = "Erlang/Elixir toolchain"


### PR DESCRIPTION
The last line of TOOLCHAIN_TARGET_TASK calls multilib_pkg_extend()
directly without the oe.utils. prefix, causing a parse error:

    NameError: name 'multilib_pkg_extend' is not defined

All other lines in the same variable already use the correct
oe.utils.multilib_pkg_extend() form.